### PR TITLE
Allow git-dch to run in a subdirectory

### DIFF
--- a/gbp/git/repository.py
+++ b/gbp/git/repository.py
@@ -92,7 +92,7 @@ class GitRepository(object):
         try:
             out, dummy, ret = self._git_inout('rev-parse', ['--show-cdup'],
                                               capture_stderr=True)
-            if ret or out.strip():
+            if ret:
                 raise GitRepositoryError("No Git repository at '%s': '%s'" % (self.path, out))
         except GitRepositoryError:
             raise # We already have a useful error message


### PR DESCRIPTION
The --show-cdup flag will output the parent path if "git rev-parse" is being run from a subdirectory. The previous conditional would fail in that case. Git returns a proper 0/128 exit code for "git rev-parse" (tested with versions 1.7.9.5, 1.9.0 and 1.9.1) if it's run outside of a repo, so the `if ret` should be sufficient.
