### PR TITLE
dch: workaround to make option '--git-author' work

### DIFF
--- a/gbp/scripts/dch.py
+++ b/gbp/scripts/dch.py
@@ -469,6 +469,15 @@ def main(argv):
             if v:
                 version_change['version'] = v
 
+        if add_section and options.git_author:
+            git_author, git_email = get_author_email(repo, True)
+            cp.add_section(distribution="UNRELEASED", msg='',
+                           version=version_change,
+                           author=git_author,
+                           email=git_email,
+                           dch_options=dch_options)
+            add_section = False
+
         i = 0
         for c in commits:
             i += 1


### PR DESCRIPTION
git-dch option '--git-author' doesn't work when we want to use user.name and
user.email from git-config as changelog section trailer due to a possible bug
in dch.
This patch does a workaround on this issue.

Debian bug #740566 discussed about this.
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=740566
