### PR TITLE
Fix orig-tarball creation on cloned repos

### DIFF
--- a/gbp/scripts/buildpackage.py
+++ b/gbp/scripts/buildpackage.py
@@ -248,7 +248,8 @@ def get_upstream_tree(repo, cp, options):
         upstream_tree = repo.version_to_tag(options.upstream_tag,
                                             cp['Upstream-Version'])
     elif options.upstream_tree.upper() == 'BRANCH':
-        if not repo.has_branch(options.upstream_branch):
+        if (not repo.has_branch(options.upstream_branch) and
+            not repo.has_branch(options.upstream_branch, remote=True)):
             raise GbpError("%s is not a valid branch" % options.upstream_branch)
         upstream_tree = options.upstream_branch
     else:


### PR DESCRIPTION
upstream branch or pristine-tar lookup is not working if repo is  a
fresh clone. When pristine-tar and upstream branches are only available
as remotes branches.