### PR TITLE
git-dch --git-author: separate author and email

### DIFF
--- a/gbp/deb/changelog.py
+++ b/gbp/deb/changelog.py
@@ -245,8 +245,10 @@ class ChangeLog(object):
             args.extend(["--release", "--no-force-save-on-release"])
             msg = None
 
-        if author and email:
-            env = {'DEBFULLNAME': author, 'DEBEMAIL': email}
+        if author:
+            env['DEBFULLNAME'] = author
+        if email:
+            env['DEBEMAIL'] = email
 
         if distribution:
             args.append("--distribution=%s" % distribution)


### PR DESCRIPTION
Allow --git-author to work if either author or email is not specified
in the git config, taking the other config option into account.