### PR TITLE
Fix upstream-tag and non-upstream-tag clashes

### DIFF
--- a/gbp/deb/git.py
+++ b/gbp/deb/git.py
@@ -63,7 +63,8 @@ class DebianGitRepository(GitRepository):
                     return None
         return None
 
-    def debian_version_from_upstream(self, upstream_tag_format, commit='HEAD',
+    def debian_version_from_upstream(self, upstream_tag_format,
+                                     upstream_branch, commit='HEAD',
                                      epoch=None):
         """
         Build the Debian version that a package based on upstream commit
@@ -71,13 +72,15 @@ class DebianGitRepository(GitRepository):
 
         @param upstream_tag_format: the tag format on the upstream branch
         @type upstream_tag_format: C{str}
+        @param upstream_branch: the upstream branch
+        @type upstream_branch: C{str}
         @param commit: the commit to search for the latest upstream version
         @param epoch: an epoch to use
         @returns: a new debian version
         @raises GitRepositoryError: if no upstream tag was found
         """
         pattern = upstream_tag_format % dict(version='*')
-        tag = self.find_tag(commit, pattern=pattern)
+        tag = self.find_branch_tag(commit, upstream_branch, pattern=pattern)
         version = self.tag_to_version(tag, upstream_tag_format)
 
         version += "-1"

--- a/gbp/git/repository.py
+++ b/gbp/git/repository.py
@@ -713,6 +713,21 @@ class GitRepository(object):
         """
         return self.describe(commit, pattern, abbrev=0)
 
+    def find_branch_tag(self, commit, branch, pattern=None):
+        """
+        Find the closest tag on a certain branch to a given commit
+
+        @param commit: the commit to describe
+        @type commit: C{str}
+        @type branch: C{str}
+        @param pattern: only look for tags matching I{pattern}
+        @type pattern: C{str}
+        @return: the found tag
+        @rtype: C{str}
+        """
+        base_commit = self.get_merge_base(commit, branch)
+        return self.describe(base_commit, pattern, abbrev=0)
+
     def get_tags(self, pattern=None):
         """
         List tags

--- a/tests/11_test_dch_main.py
+++ b/tests/11_test_dch_main.py
@@ -57,6 +57,7 @@ class TestScriptDch(DebianGitTestRepo):
         self.repo.create_tag("upstream/0.9", msg="upstream version 0.9")
         self.add_file("bar", "foo")
         self.repo.create_tag("upstream/1.0", msg="upstream version 1.0")
+        self.repo.create_branch("upstream")
         self.repo.create_branch("debian")
         self.repo.set_branch("debian")
         self.upstream_tag = "upstream/%(version)s"
@@ -66,7 +67,7 @@ class TestScriptDch(DebianGitTestRepo):
         self.add_file("debian/changelog", cl_debian)
         self.add_file("debian/control", """Source: test-package\nSection: test\n""")
         self.options = ["--upstream-tag=%s" % self.upstream_tag, "--debian-branch=debian",
-                        "--id-length=0", "--spawn-editor=/bin/true"]
+                        "--upstream-branch=upstream", "--id-length=0", "--spawn-editor=/bin/true"]
         self.repo.create_tag(deb_tag, msg=deb_tag_msg, commit="HEAD~1")
 
 

--- a/tests/test_GitRepository.py
+++ b/tests/test_GitRepository.py
@@ -309,6 +309,23 @@ def test_find_tag():
     GitRepositoryError: Can't describe HEAD. Git error: fatal: No names found, cannot describe anything.
     """
 
+def test_find_branch_tag():
+    """
+    Find the closest tags on a certain branch to a given commit
+
+    Methods tested:
+         - L{gbp.git.GitRepository.find_branch_tag}
+
+    >>> import gbp.git
+    >>> repo = gbp.git.GitRepository(repo_dir)
+    >>> repo.find_branch_tag('HEAD', 'master', 'tag*')
+    'tag2'
+    >>> repo.find_branch_tag('HEAD', 'master', 'v*')   # doctest:+ELLIPSIS
+    Traceback (most recent call last):
+    ...
+    GitRepositoryError: Can't describe .... Git error: fatal: No names found, cannot describe anything.
+    """
+
 def test_move_tag():
     """
     Move a tag


### PR DESCRIPTION
In some unfortunate cases you might have something like this:

$ git tag
v1.0
vyatta/1.0-0something1

... where later tag is closer to describe current HEAD.

With upstream-tag set to v%(version)s find_tag() is going to propose
something based on vyatta/1.0-0something1 which is not expected.

To avoid this kind of tag clash, supporting a tiny regex subset could
help on that:

e.g. upstream-tag = v[0-9]%(version)s

Note: Debian allows upstream_versions starting with alphanumeric
characters. So this [0-9] shouldn't get hardcoded in the find_tag()
function.
https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-Version