### PR TITLE
Restore correct version-guessing for -0releases

### DIFF
--- a/gbp/deb/git.py
+++ b/gbp/deb/git.py
@@ -65,7 +65,7 @@ class DebianGitRepository(GitRepository):
 
     def debian_version_from_upstream(self, upstream_tag_format,
                                      upstream_branch, commit='HEAD',
-                                     epoch=None):
+                                     epoch=None, debian_release=True):
         """
         Build the Debian version that a package based on upstream commit
         I{commit} would carry taking into account a possible epoch.
@@ -76,6 +76,7 @@ class DebianGitRepository(GitRepository):
         @type upstream_branch: C{str}
         @param commit: the commit to search for the latest upstream version
         @param epoch: an epoch to use
+        @param debian_release: set True if this a debian package release
         @returns: a new debian version
         @raises GitRepositoryError: if no upstream tag was found
         """
@@ -83,7 +84,9 @@ class DebianGitRepository(GitRepository):
         tag = self.find_branch_tag(commit, upstream_branch, pattern=pattern)
         version = self.tag_to_version(tag, upstream_tag_format)
 
-        version += "-1"
+        if debian_release:
+            version += "-1"
+
         if epoch:
             version = "%s:%s" % (epoch, version)
         return version

--- a/gbp/scripts/dch.py
+++ b/gbp/scripts/dch.py
@@ -40,15 +40,17 @@ snapshot_re = re.compile("\s*\*\* SNAPSHOT build @(?P<commit>[a-z0-9]+)\s+\*\*")
 
 def guess_version_from_upstream(repo, upstream_tag_format, upstream_branch, cp):
     """
-    Guess the version based on the latest version on the upstream branch
+    Guess the version based on the latest version on the upstream branch.
+    If the version in dch is already higher this function returns None.
     """
     try:
         version = repo.debian_version_from_upstream(upstream_tag_format,
                                                     upstream_branch,
-                                                    epoch=cp.epoch)
+                                                    epoch=cp.epoch,
+                                                    debian_release=False)
         gbp.log.debug("Found upstream version %s." % version)
         if compare_versions(version, cp.version) > 0:
-            return version
+            return "%s-1" % version
     except GitRepositoryError as e:
         gbp.log.debug("No upstream tag found: %s" % e)
     return None

--- a/tests/03_test_dch_guess_version.py
+++ b/tests/03_test_dch_guess_version.py
@@ -76,3 +76,25 @@ class TestGuessVersionFromUpstream(testutils.DebianGitTestRepo):
                                                   cp)
 
         self.assertEqual('1.0-1', guessed)
+
+    def test_guess_upstream_tag_zero_release(self):
+        """Guess with existing -0... releases"""
+        cp = testutils.MockedChangeLog('0.9-0vyatta2')
+
+        tagformat = 'upstream/%(version)s'
+        uversion = '0.9'
+        upstream_branch = 'upstream'
+
+        self.add_file('doesnot', 'matter')
+        self.repo.create_branch('upstream')
+        tag = self.repo.version_to_tag(tagformat, uversion)
+        self.repo.create_tag(name=tag, msg="Upstream release %s" % uversion,
+                             sign=False)
+        self.repo.set_branch('master')
+        self.add_file('doesnot2', 'matter')
+
+        guessed = dch.guess_version_from_upstream(self.repo,
+                                                  tagformat,
+                                                  upstream_branch,
+                                                  cp)
+        self.assertEqual(None, guessed)


### PR DESCRIPTION
With commit 59254996d740b8b8a0db306a7e04950a5f4e51b8 the version
guessing behavior changed. gbp dch --release suggested to bump
the package version from: 1.0-0vyatta1 to 1.0-1
Old and expected beahviour is: 1.0-0vyatta2