### PR TITLE
Add dh-python to Build-Depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,6 +5,7 @@ Maintainer: Guido Günther <agx@sigxcpu.org>
 Build-Depends:
  bash-completion,
  debhelper (>= 9~),
+ dh-python,
  docbook-utils,
  gtk-doc-tools,
  jade,


### PR DESCRIPTION
in response to the friendly warning from dh_python2:

    W: dh_python2:479: Please add dh-python package to Build-Depends

Many thanks!