### PR TITLE
Copy-edit git-buildpackage documentations

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -4,12 +4,12 @@ The tests are run via
 
     python setup.py nosetests
 
-To also run the component tests you need to initialize the git submodules once
+To also run the component tests, you need to initialize the git submodules once
 via:
 
     git submodule update --init --recursive
 
-This will fetch the necessary binary data for the DEB and RPM component tests
+This will fetch the necessary binary data for the DEB and RPM component tests,
 and the tests are from now on included within each regular test run.
 
 

--- a/README
+++ b/README
@@ -1,11 +1,11 @@
 Git-buildpackage
 ----------------
 This is a bunch of scripts to ease the development of Debian packages with git.
-For more documentation on how to use these tools see the manual online at:
+For more documentation on how to use these tools, see the manual online at:
 
     http://honk.sigxcpu.org/projects/git-buildpackage/manual-html/gbp.html
 
-On Debian systems this can be found in
+On Debian systems, this can be found in
 /usr/share/doc/git-buildpackage/manual-html.
 
 The API documentation of the gbp module can be found at:

--- a/docs/chapters/building.sgml
+++ b/docs/chapters/building.sgml
@@ -1,51 +1,51 @@
 <chapter id="gbp.building">
     <title>Building packages from the &git; repository</title>
     <para>
-    In order to build a &debian; package from the &git; repository you use:
-    &gbp-buildpackage;. This builds the upstream tarball as will be described below and
-    invokes &debuild; to build the package. To use another build command you
-    can use the <option>--git-builder</option> option as described later in the manual
+    In order to build a &debian; package from the &git; repository, you use:
+    &gbp-buildpackage;. This builds the upstream tarball (as will be described below) and
+    invokes &debuild; to build the package. To use another build command, you
+    can use the <option>--git-builder</option> option as described later in the manual,
     but &debuild; is nice since it can invoke <productname>lintian</productname>.
     During the development phase (when you're either not on the
     <emphasis>debian-branch</emphasis> or when you have uncommitted changes in
-    your repository) you'll usually use:
+    your repository), you'll usually use:
     </para>
 <screen>
 &gbp-buildpackage; <option>--git-ignore-new</option>
 </screen>
-    <para>If &gbp-buildpackage; doesn't find a valid upstream tarball it will
+    <para>If &gbp-buildpackage; doesn't find a valid upstream tarball, it will
     create one by looking at the tag matching the upstream version. To change
-    this behaviour see the <option>--git-upstream-tree</option> option.
+    this behaviour, see the <option>--git-upstream-tree</option> option.
     </para><para>
     If you want to recreate the original tarball using the additional
-    information from the <option>pristine-tar branch</option> you have to
+    information from the <option>pristine-tar branch</option>, you have to
     specify the <option>--git-pristine-tar</option> option. This will make sure
     the upstream tarball matches exactly the one imported. Using this option is
     the recommended way of recreating the upstream tarball.
     </para>
-    <para>Once you're satisfied with the build and want to do a release you commit all
+    <para>Once you're satisfied with the build and want to do a release, you commit all
     your changes and issue:</para>
 <screen>
 &gbp-buildpackage; <option>--git-tag</option>
 </screen>
     <para>This will again build the &debian; package and tag the final result after
-    extracting the current version from the changelog. If you want &gpg; signed
-    tags you can use the <option>--git-sign</option> and
-    <option>--git-keyid</option> options. To save typing these option can be
+    extracting the current version from the changelog. If you want &gpg;-signed
+    tags, you can use the <option>--git-sign</option> and
+    <option>--git-keyid</option> options. To save typing, these option can be
     specified via the configuration files. You can furthermore change the tag
     format used when creating tags with the <option>debian-tag</option>
-    option, the default is <replaceable>debian/&lt;version&gt;</replaceable>.</para>
+    option; the default is <replaceable>debian/&lt;version&gt;</replaceable>.</para>
     <sect1 id="gbp.building.export">
     <title>Using a separate build dir</title>
     <para>Tools like &svn-buildpackage; use a separate build-area. To achieve a similar behaviour
-    with &gbp-buildpackage; use the <option>--git-export-dir</option> option:</para>
+    with &gbp-buildpackage;, use the <option>--git-export-dir</option> option:</para>
 <screen>
 &gbp-buildpackage; <option>--git-export-dir</option>=<replaceable>../build-area/</replaceable>
 </screen>
     <para>This will export the head of the current branch to
-    <replaceable>../build-area/package-version</replaceable>, build the
-    package. If you don't want to export the current branch head you can use
-    <option>--git-export</option> to export any treeish object, here are some
+    <replaceable>../build-area/package-version</replaceable> and build the
+    package. If you don't want to export the current branch head, you can use
+    <option>--git-export</option> to export any treeish object.  Here are some
     examples:</para>
 <screen>
 &gbp-buildpackage; <option>--git-export-dir</option>=<replaceable>../build-area</replaceable> <option>--git-export</option>=<replaceable>debian/0.4.3</replaceable>
@@ -55,11 +55,11 @@
 &gbp-buildpackage; <option>--git-export-dir</option>=<replaceable>../build-area</replaceable> <option>--git-export</option>=<replaceable>WC</replaceable>
 </screen>
     <para>The special argument <replaceable>INDEX</replaceable> exports the
-    state of the current index which can be used to include staged but uncommitted
+    state of the current index, which can be used to include staged but uncommitted
     changes in the build. Whereas the special argument
     <replaceable>WC</replaceable> exports the current working copy as is.</para>
-    <para>If you want to default to build in a separate build area you can
-    specify the directory to use in the gbp.conf.
+    <para>If you want to default to build in a separate build area, you can
+    specify the directory to use in the <filename>gbp.conf</filename> file.
 <programlisting>
 [git-buildpackage]
 # use a build area relative to the git repository
@@ -68,7 +68,7 @@ export-dir=../build-area
 #export-dir=/home/debian-packages/build-area
 </programlisting>
     &gbp-buildpackage; will cleanup the build-area after a successful build. If
-    you want to keep the build tree use <replaceable>--git-no-purge</replaceable>.
+    you want to keep the build tree, use <replaceable>--git-no-purge</replaceable>.
     </para>
     </sect1>
     <sect1 id="gbp.building.hooks">
@@ -76,9 +76,9 @@ export-dir=../build-area
     <para>
     Besides the commands for cleaning the package build dir
     (<option>cleaner</option>) and building the package
-    (<option>builder</option>) you can also invoke hooks during the package
+    (<option>builder</option>), you can also invoke hooks during the package
     build: immediately before a build (<option>prebuild</option>),
-    after a successful build (<option>postbuild</option>) and after
+    after a successful build (<option>postbuild</option>), and after
     creating a tag (<option>posttag</option>). Typical applications are running
     <productname>lintian</productname> or pushing changes into a remote
     repository.
@@ -88,11 +88,11 @@ export-dir=../build-area
 	<para>&gbp-buildpackage; exports several variables into the
 	<option>posttag</option>'s environment (for details see the <xref
 	linkend="man.gbp.buildpackage">).
-	To invoke &lintian; we need to tell it where to find the changes file:
+	To invoke &lintian;, we need to tell it where to find the changes file:
 <programlisting>
 <command>git-buildpackage</command> <option>--git-postbuild</option>=<replaceable>'lintian $GBP_CHANGES_FILE'</replaceable>
 </programlisting>
-        To call &lintian; automatically after each successful build add:
+        To call &lintian; automatically after each successful build, add:
 <programlisting>
 <option>postbuild</option>=<replaceable>lintian $GBP_CHANGES_FILE</replaceable>
 </programlisting>
@@ -101,7 +101,7 @@ export-dir=../build-area
     </sect2>
     <sect2 id="gbp.building.push">
     <title>Pushing into a remote repository</title>
-	<para>If you want to push your changes automatically after a successful build and tag
+	<para>If you want to push your changes automatically after a successful build and tag,
 	you can use &gbp-buildpackage;'s posttag hook. A very simple invocation would look like this:
 <programlisting>
 <command>git-buildpackage</command> <option>--git-tag</option> <option>--git-posttag</option>=<replaceable>"git push && git push --tags"</replaceable>
@@ -109,7 +109,7 @@ export-dir=../build-area
 	This assumes you have set up a remote repository to push to in
         <filename>.git/config</filename>.</para>
 
-	<para>Usually you want to make sure you don't push out any
+	<para>Usually, you want to make sure you don't push out any
         unrelated changes into the remote repository. This is handled by the
         following hook which only pushes out the created tag to where you pulled
         from and also forwards the corresponding remote branch to that position:
@@ -141,13 +141,13 @@ echo "done."
 </programlisting>
 	<envar>GBP_TAG</envar>, <envar>GBP_SHA1</envar>
         and <envar>GBP_BRANCH</envar> are passed to the hook via the
-        environment. To call this hook automatically upon tag creation add:
+        environment. To call this hook automatically upon tag creation, add:
 <programlisting>
 <option>posttag</option>=<replaceable>"gbp-posttag-push"</replaceable>
 </programlisting>
 	to your <filename>.gbp.conf</filename> and make sure <filename>gbp-push</filename>
 	is somewhere in your <envar>$PATH</envar>. On &debian;
-	systems a more complete example can be found in
+	systems, a more complete example can be found in
 	<filename>/usr/share/doc/examples/git-buildpackage/examples/gbp-posttag-push</filename>.
     </para>
     </sect2>
@@ -159,19 +159,19 @@ echo "done."
 	for the postexport action is to allow further adjustment of
 	the sources prior to building the package. A typical use case
 	scenario is to allow creating multiple source and binary
-	packages from one &debian; branch - e.g. the bootstrap gcc and
+	packages from one &debian; branch, e.g. the bootstrap gcc and
 	in the next stage the full gcc.
     </para>
-    <para> The postexport action, postpones the creation of the
+    <para>The postexport action postpones the creation of the
       upstream tarball, so that the metadata for creating it is
       already present in the exported source tree. The example
-      postexport script below (crosstoolchain-expand.sh) expands
-      changelog, lintian override files, rules and control files
-      according to an environment variable 'PKG_FLAVOR'.
+      postexport script below (<filename>crosstoolchain-expand.sh</filename>)
+      expands changelog, lintian override files, rules and control files
+      according to an environment variable <envar>PKG_FLAVOR</envar>.
     </para>
 
-    <para>Sample gbp.conf - enables source tree export by specifying
-    the export directory:
+    <para>Sample <filename>gbp.conf</filename> - enables source tree export
+    by specifying the export directory:
     </para>
 <programlisting>
 [git-buildpackage]
@@ -184,7 +184,7 @@ postexport = crosstoolchain-expand.sh
 </programlisting>
 
 
-<para>Sample postexport script: crosstoolchain-expand.sh</para>
+<para>Sample postexport script: <filename>crosstoolchain-expand.sh</filename></para>
 <programlisting>
 #!/bin/sh
 #
@@ -276,7 +276,7 @@ exit 0
     for an example workflow.
     </para>
     <para>
-    In order to avoid a patched (unclean) source tree after the build you
+    In order to avoid a patched (unclean) source tree after the build, you
     can use &dpkg-source;'s <option>unapply-patches</option> option and
     tell &git; to ignore the <filename>.pc</filename> directory.
     <filename>/usr/share/doc/git-buildpackage/examples/gbp-configure-unpatched-source</filename>

--- a/docs/chapters/cfgfile.sgml
+++ b/docs/chapters/cfgfile.sgml
@@ -62,7 +62,7 @@
 <option>upstream-branch</option>=<replaceable>dfsgfree</replaceable>
 </screen>
 <para>
-    in the config file. In the special case of &gbp-buildpackage; the stripped
+    in the config file. In the special case of &gbp-buildpackage;, the stripped
     prefix is not '--' but '--git-'. Here's a more complete example:
 </para>
 <programlisting>
@@ -91,6 +91,6 @@ upstream-branch=notdfsgclean
 git-log=--no-merges
 </programlisting>
 <para>
-For more details see the <xref linkend="man.gbp.conf"> manual page.
+For more details, see the <xref linkend="man.gbp.conf"> manual page.
 </para>
 </chapter>

--- a/docs/chapters/import.sgml
+++ b/docs/chapters/import.sgml
@@ -9,20 +9,20 @@
     </screen>
     This will create a new &git; repository named after the imported package, put
     the upstream sources onto the <option>upstream-branch</option> and the
-    &debian; patch on the <option>debian-branch</option>. In case of a debian
-    native package only the <option>debian-branch</option> is being used.
+    &debian; patch on the <option>debian-branch</option>. In case of a &debian;
+    native package, only the <option>debian-branch</option> is being used.
     You can specify alternative branch names via the
     <option>--upstream-branch</option> and <option>--debian-branch</option>
-    options or via the <option>upstream-branch</option> and
+    options, or via the <option>upstream-branch</option> and
     <option>debian-branch</option> options in the configuration file.
     </para>
     <para>
     If you want to be able to exactly recreate the original tarball
-    (orig.tar.gz) from &git; you should also specify the
+    (orig.tar.gz) from &git;, you should also specify the
     <option>--pristine-tar</option> option.  This is recommended.
     </para>
     <para>
-    If you want to import further versions you can change into your shiny new
+    If you want to import further versions, you can change into your shiny new
     &git; repository and just continue with the same command:
     <screen>
 cd package/
@@ -50,7 +50,7 @@ by version number.
     <sect1 id="gbp.import.new.upstream">
     <title>Importing a new upstream version</title>
     <para>Change into your &git; repository (which can be empty), make sure it
-    has all local modifications committed and run either of:
+    has all local modifications committed, and run either of:
     <screen>
 &gbp-import-orig; <filename>/path/to/package_0.2.orig.tar.gz</filename>
 &gbp-import-orig; <filename>/path/to/package_0.2.tar.bz2</filename>
@@ -59,7 +59,7 @@ by version number.
     This puts the upstream sources onto the <option>upstream-branch</option> and
     tags them accordingly (the default tag format is
     <replaceable>upstream/%(version)s</replaceable>).
-    The result is then merged onto the <option>debian-branch</option>
+    The result is then merged onto the <option>debian-branch</option>,
     and a new &debian; changelog entry is created. You can again specify
     different branch names via the <option>--upstream-branch</option> and
     <option>--debian-branch</option> options.
@@ -69,7 +69,7 @@ by version number.
 &gbp-import-orig; --uscan
     </screen>
     </para>
-    <para> You can also filter out content
+    <para>You can also filter out content
     you don't want imported:
     <screen>
 &gbp-import-orig; <option>--filter</option>=<replaceable>'CVS/*'</replaceable> <filename>/path/to/package_0.2.orig.tar.gz</filename>
@@ -78,18 +78,18 @@ by version number.
     complex filtering.
     </para>
     <para>
-    If you expect a merge conflict you can delay the merge to the
-    <option>debian-branch</option> via the <option>--no-merge</option> and pull in
+    If you expect a merge conflict, you can delay the merge to the
+    <option>debian-branch</option> via the <option>--no-merge</option> option and pull in
     the changes from the <option>upstream-branch</option> later.
     </para>
     <para>
     If you want to be able to exactly recreate the original tarball
-    (orig.tar.gz) from &git; you should also specify the
+    (orig.tar.gz) from &git;, you should also specify the
     <option>--pristine-tar</option> option.  This is recommended.
     </para>
-    <para>To customize the commit message used by &gbp-import-orig; use
+    <para>To customize the commit message used by &gbp-import-orig;, use
     the <option>--import-msg</option> option. This string is a standard
-    python format string, into which the
+    Python format string, into which the
     <replaceable>version</replaceable> variable is interpolated. (i.e.,
     use <replaceable>%(version)s</replaceable> in your message to get
     the imported upstream version).
@@ -99,13 +99,13 @@ by version number.
     <sect1 id="gbp.import.convert">
     <title>Converting an existing &git; repository</title>
     <para>
-    If the &git; repository wasn't created with &gbp-import-dsc; you have to tell
-    &gbp-buildpackage; and friends where to find the upstream sources.
+    If the &git; repository wasn't created with &gbp-import-dsc;, you have to
+    tell &gbp-buildpackage; and friends where to find the upstream sources.
     </para>
     <sect2>
     <title>Upstream sources on a branch</title>
     <para>
-    If the upstream sources are already on a separate branch things are pretty
+    If the upstream sources are already on a separate branch, things are pretty
     simple. You can either rename that branch to the default
     <option>upstream-branch</option> name <emphasis>upstream</emphasis> with:
     <screen>
@@ -130,7 +130,7 @@ EOF
     <title>Upstream sources not on a branch</title>
     <para>
     If you don't have an upstream branch but started your repository with only
-    the upstream sources (not the &debian; patch) you can simply branch from that
+    the upstream sources (not the &debian; patch), you can simply branch from that
     point. So use &gitkcmd; or &gitcmd;-log to locate the commit-id of that commit
     and create the upstream branch from there, e.g.:
 <screen>
@@ -175,46 +175,46 @@ EOF
     <sect1 id="gbp.import.fromscratch">
     <title>Starting a &debian; package from scratch</title>
     <para>
-    So far we assumed you already have a &debian; package to start with but
-    what if you want to start a new package? First create an empty repository:
+    So far, we assumed you already have a &debian; package to start with, but
+    what if you want to start a new package? First, create an empty repository:
     </para>
     <screen>
 <command>mkdir</command> package-0.1
 <command>cd</command> package-0.1
 <command>git init</command>
     </screen>
-    <para>Then you import the upstream sources, branch off the
+    <para>Then, you import the upstream sources, branch off the
     <option>upstream-branch</option> branch and add the &debian; files (e.g. via dh_make):
     <screen>
 &gbp-import-orig; <option>-u</option> <replaceable>0.1</replaceable> <filename>../package-0.1.tar.gz</filename>
 <command>dh_make</command>
     </screen>
-    That's it, you're done. If you want to publish you're new repository you can use &gbp-create-remote-repo;.
+    That's it, you're done. If you want to publish your new repository, you can use &gbp-create-remote-repo;.
     </para>
     </sect1>
 
     <sect1 id="gbp.import.upstream-git">
     <title>When upstream uses Git</title>
     <para>
-      If upstream already uses git for packaging there are several ways to handle packaging. Two of them will
+      If upstream already uses git for packaging, there are several ways to handle packaging. Two of them will
       be described in a bit detail here:
     </para>
 
       <sect2 id="gbp.import.upstream.git.notarball">
 	<title>No upstream tarballs</title>
-	<para>If upstream doesn't build upstream tarballs or you don't care about them the simplest
-	  way is to clone upstreams repository and create a separate packaging branch in there.
+	<para>If upstream doesn't build upstream tarballs, or you don't care about them, the simplest
+	  way is to clone upstream's repository and create a separate packaging branch in there.
 	</para>
 
 	<para>
-	  In order to help &gbp-buildpackage; to find upstream tags you need to specify the format
+	  In order to help &gbp-buildpackage; to find upstream tags, you need to specify the format
 	  using the <option>--git-upstream-tag</option> command line option or the the <option>upstream-tag</option>
 	  configuration variable.
 	</para>
 
 	<para>
 	  A common upstream format is to put a <replaceable>v</replaceable> in front of the version number.
-	  In this case the configuration option would look like:
+	  In this case, the configuration option would look like:
 	</para>
 	<screen>
 [git-buildpackage]
@@ -224,20 +224,20 @@ upstream-tag = v%(version)s
 	  <replaceable>version</replaceable> will be replaced with the upstream version number as read from
 	  <filename>debian/changelog</filename>.
 	</para>
-	<para>If you're using &pristine-tar; you can make &gbp-buildpackage commit the generated tarball back to the
+	<para>If you're using &pristine-tar;, you can make &gbp-buildpackage commit the generated tarball back to the
 	  pristine-tar branch by using the <option>--git-pristine-tar-commit</option> option. This will make sure
 	  others building your package can regenerate the tarball you generated for building the &debian; package.
 	</para>
 
 	<sect3>
 	  <title>Step by step</title>
-	<para>To not make any assumptions about &gbp;'s configuration the following steps have all options given
-	  in its long versions on the command line . You can add these
+	<para>To not make any assumptions about &gbp;'s configuration, the following steps have all options given
+	  in its long versions on the command line. You can add these
 	  to &gbp.conf; to save lots of typing.
 	</para>
 
-	<para>First we clone the upstream repository. To avoid any dis ambiguities between the &debian; packaging repository
-	  and the upstream repository we name the upstream repository <replaceable>upstream</replaceable> instead of the
+	<para>First, we clone the upstream repository. To avoid any ambiguities between the &debian; packaging repository
+	  and the upstream repository, we name the upstream repository <replaceable>upstream</replaceable> instead of the
 	  default <replaceable>origin</replaceable>.
 	  <screen>
 	    git clone --no-checkout -o upstream git://git.example.com/libgbp.git
@@ -245,13 +245,13 @@ upstream-tag = v%(version)s
 	    git checkout -b debian/sid v1.0
 	  </screen>
 	  The above makes sure we have <replaceable>debian/sid</replaceable> for the &debian; packaging. We didn't create
-	  any <replaceable>upstream/*</replaceable> branches, they're not needed for the packaging and only need to be
-	  kept up to date. After adding the &debian; packaging we build the package. This assumes you're using &pristine-tar;
+	  any <replaceable>upstream/*</replaceable> branches; they're not needed for the packaging and only need to be
+	  kept up to date. After adding the &debian; packaging, we build the package. This assumes you're using &pristine-tar;
 	  and upstream uses a version number format as described above:
 	  <screen>
 	    gbp buildpackage --git-pristine-tar --git-pristine-tar-commit --git-upstream-tag='v%(version)s' --git-debian-branch=debian/sid
 	  </screen>
-	  When updating to a new upstream version we simply fetch from upstream and merge in the new tag. Afterwards we
+	  When updating to a new upstream version, we simply fetch from upstream and merge in the new tag. Afterwards, we
 	  update the changelog and build the package:
 	  <screen>
 	    git fetch upstream
@@ -260,15 +260,15 @@ upstream-tag = v%(version)s
 	    gbp buildpackage --git-ignore-new --git-pristine-tar --git-pristine-tar-commit --git-upstream-tag='v%(version)s'
 	  </screen>
 	  Note that the above &gbp-dch; call makes sure we only pickup changes in the <filename>debian/</filename>
-	  directory. Since we told it to build a snapshot changelog entry and we didn't commit the changelog yet
-	  we need to tell &gbp-buildpackage; that the working directory is unclean via the <option>--git-ignore-new</option>.
-	  Once everything looks good commit the changelog and build a release version:
+	  directory. Since we told it to build a snapshot changelog entry and we hadn't commit the changelog yet,
+	  we need to tell &gbp-buildpackage; that the working directory is unclean via the <option>--git-ignore-new</option> option.
+	  Once everything looks good, commit the changelog and build a release version:
 	  <screen>
 	    gbp dch --release --auto --git-debian-branch=debian/sid
 	    git commit -m"Release 1.1-1" debian/changelog
 	    gbp buildpackage --git-upstream-tag='v%(version)s' --git-debian-branch=debian/sid
 	  </screen>
-	  If you want to share you're repository with others you can use &gbp-create-remote-repo; and &gbp-pull; as usual.
+	  If you want to share your repository with others, you can use &gbp-create-remote-repo; and &gbp-pull; as usual.
 	</para>
 	</sect3>
       </sect2>
@@ -277,9 +277,9 @@ upstream-tag = v%(version)s
 	<title>Upstream tarballs</title>
 	<para>If you want to track upstream's &git; but continue to import the upstream tarballs,
 	  e.g. to make sure the tarball uploaded
-	  to &debian; has the same checksum as upstream's you can use the <option>--upstream-vcs-tag</option> option
+	  to &debian; has the same checksum as upstream's, you can use the <option>--upstream-vcs-tag</option> option
 	  when importing new tarballs with &gbp-import-orig;. Assuming you have the upstream source in your
-	  repository with a tag <replaceable>v0.0.1</replaceable> you can use:
+	  repository with a tag <replaceable>v0.0.1</replaceable>, you can use:
 	  <screen>
 	    &gbp-import-orig; --upstream-vcs-tag=v0.0.1 foo_0.0.1.orig.tar.gz
 	  </screen>
@@ -292,11 +292,11 @@ upstream-tag = v%(version)s
     <sect1 id="gbp.branch.naming">
       <title>Branch layout</title>
       <para>
-	By default &gbp; uses one branch to keep the &debian; packaging called <emphasis>master</emphasis>
+	By default, &gbp; uses one branch to keep the &debian; packaging called <emphasis>master</emphasis>
 	and a branch to keep the upstream packaging called <emphasis>upstream</emphasis>.
       </para>
       <para>
-	This layout is simple to get started but fails short if one needs to maintain several versions of
+	This layout is simple to get started but falls short if one needs to maintain several versions of
 	the package at the same time. Therefore the following layout is recommended:
       </para>
 
@@ -348,14 +348,14 @@ upstream-tag = v%(version)s
 	  </term>
 	  <listitem>
 	    <para>
-	      the dfsg clean upstream sources in case the cleanup is done via a &git;
+	      the DFSG-clean upstream sources in case the cleanup is done via a &git;
 	      merge from upstream to this branch.
 	    </para>
 	  </listitem>
 	</varlistentry>
       </variablelist>
       <para>
-	In case &pristine-tar; is being used there will be a single <emphasis>pristine-tar</emphasis>
+	In case &pristine-tar; is being used, there will be a single <emphasis>pristine-tar</emphasis>
 	branch that keeps all binary deltas.
       </para>
     </sect1>

--- a/docs/chapters/intro.sgml
+++ b/docs/chapters/intro.sgml
@@ -33,7 +33,7 @@
 	no meaning for &debian; native packages</para></footnote>.
 	This is necessary to be able to import
 	and merge in new upstream versions via &gbp-import-orig;.
-	To distinguish these two branches the following terminology
+	To distinguish these two branches, the following terminology
 	<footnote><para>corresponding to the command
 	line and config file options</para></footnote> is used:
 	</para>
@@ -54,13 +54,13 @@
 	branch name used in the &git; repository is
 	<emphasis>pristine-tar</emphasis>) holds the necessary additional
 	information to recreate the original tarball from the
-	<option>upstream-branch</option>. In order to use this feature you need
+	<option>upstream-branch</option>. In order to use this feature, you need
 	to install the &pristine-tar; package.</para></listitem>
 
 	<listitem><para> There can be one or more <option>patch-queue
 	branches</option>. Every patch-queue branch is related to a
 	<option>debian-branch</option>. If the <option>debian-branch</option> is called
-	<emphasis>master</emphasis> the corresponding patch-queue branch is
+	<emphasis>master</emphasis>, the corresponding patch-queue branch is
 	called <emphasis>patch-queue/master</emphasis>. The patch-queue branch is 
 	the &debian; branch plus the contents of
 	<emphasis>debian/patches</emphasis> applied. These branches are managed
@@ -69,24 +69,24 @@
 	</itemizedlist>
 
 	<para>You're completely
-	free to pick any repository layout and the branch names above are only
-	&gbp;'s defaults. They can be changed at any point in time
+	free to pick any repository layout; the branch names above are only
+	&gbp;'s defaults. They can be changed at any point in time,
 	and you can work with an arbitrary number of branches.
-	For example branches like  <emphasis>nmu</emphasis>,
+	For example, branches like <emphasis>nmu</emphasis>,
 	<emphasis>backports</emphasis> or <emphasis>stable</emphasis> might
-	(temporarily or permanent) become your <option>debian-branch</option>
+	(temporarily or permanently) become your <option>debian-branch</option>,
 	and branches like <emphasis>dfsg</emphasis> or
 	<emphasis>snapshots</emphasis> might become your
-	<option>upstream-branch</option> - it doesn't matter if these branches
+	<option>upstream-branch</option>&mdash;it doesn't matter if these branches
 	are maintained with &gbp-import-orig; or not.</para>
         <para>
         A recommended branch layout is described in <xref linkend="gbp.branch.naming">.
         </para>
 
-	<para>Since &gbp-buildpackage; only works with local &git;-repositories
+	<para>Since &gbp-buildpackage; only works with local &git;-repositories,
 	you have to use <command>git push</command> in order to publish your
 	changes to remote repositories like <ulink
-	url="http://git.debian.org/">git.debian.org</ulink>, this can also be
+	url="http://git.debian.org/">git.debian.org</ulink>; this can also be
 	automatized with &gbp-buildpackage;'s <option>post-tag</option>
 	hook.</para>
 </sect1>
@@ -100,25 +100,25 @@
 	<listitem><para>Import a new &debian; package via &gbp-import-dsc;. This
 	imports the &debian; Package on the <option>debian-branch</option>
 	and the upstream sources on the <option>upstream-branch</option>.</para></listitem>
-	<listitem><para>Develop, test, commit changes. During this time you can
+	<listitem><para>Develop, test, commit changes. During this time, you can
 	always build the package with &gbp-buildpackage;. In case you have
-	uncommitted changes in your source tree you can use the
+	uncommitted changes in your source tree, you can use the
 	<option>--git-ignore-new</option> option.</para></listitem>
 	<listitem><para>Optionally you can create the &debian; changelog entries
 	using &gbp-dch; and create snapshot releases for testing using its
 	<option>--snapshot</option> option.</para></listitem>
-	<listitem><para>Once satisfied you can build the final package with
+	<listitem><para>Once satisfied, you can build the final package with
 	&gbp-buildpackage; <option>--git-tag</option>. This additionally
 	creates a tag within &git; so you can switch back to that version later
-	at any time. The format of the tags can be specified, tags can
+	at any time. The format of the tags can be specified; tags can
 	be &gpg; signed.</para></listitem>
 	<listitem><para>When a new upstream version is released and upstream
-	isn't using &git; you can import the new version via &gbp-import-orig;
+	isn't using &git;, you can import the new version via &gbp-import-orig;
 	onto the <option>upstream-branch</option>.  &gbp-import-orig; will
 	by default try to merge the new upstream version onto the
 	<option>debian-branch</option>. You can skip the merge with
-	<option>--no-merge</option>.  After resolving any potential conflicts
-	go back to the second step.  </para></listitem>
+	<option>--no-merge</option>.  After resolving any potential conflicts,
+	go back to the second step.</para></listitem>
     </orderedlist>
     <para>These steps will be explained in more details in the following sections.</para>
 </sect1>

--- a/docs/chapters/releases.sgml
+++ b/docs/chapters/releases.sgml
@@ -2,8 +2,8 @@
     <title>Releases and Snapshots</title>
     <para>When branching and merging frequently, the different &debian; changelog
     entries on the different branches tend to get into the way of the automatic
-    merge and the the merge fails - leaving the (pathological) merge to the
-    committer. In order to avoid this &gbp-dch; offers a way for creating
+    merge and the the merge fails&mdash;leaving the (pathological) merge to the
+    committer. In order to avoid this, &gbp-dch; offers a way for creating
     changelog entries from &git; commits before doing a
     release or anytime between releases.</para> 
     <para>
@@ -14,9 +14,9 @@
 <screen>
 &gbp-dch; <option>--release</option>
 </screen>
-    <para> This will look up the latest released version in the changelog,
+    <para>This will look up the latest released version in the changelog,
     increment the version in the &debian; changelog, generate changelog
-    messages from the corresponding &git; commit id up to the branch head and
+    messages from the corresponding &git; commit id up to the branch head, and
     finally spawns an editor for final changelog file editing by invoking &dch;
     <option>--release</option>.</para>
     <para>
@@ -35,7 +35,7 @@ git-buildpackage (0.3.7~1.gbp470ce2) UNRELEASED; urgency=low
 
   * add support for automatic snapshot 
 </programlisting>
-   <para>During subsequent calls with <option>--snapshot</option> this version
+   <para>During subsequent calls with <option>--snapshot</option>, this version
    number will continue to increase. Since the snapshot banners contains the
    commit id of the current branch head, &gbp-dch; can figure out what to
    append to the changelog by itself:
@@ -43,13 +43,13 @@ git-buildpackage (0.3.7~1.gbp470ce2) UNRELEASED; urgency=low
 &gbp-dch; <option>--snapshot</option> <option>--auto</option>
 </screen>
    will fetch the commit id and add changelog entries from that point to the
-   current HEAD - again auto incrementing the version number. If you don't want
+   current HEAD&mdash;again auto incrementing the version number. If you don't want
    to start at that commit id, you can specify any id or tag with:</para>
 <screen>
 &gbp-dch; <option>--since</option>=<replaceable>e76a6a180a57701ae4ae381f74523cacb3152780</replaceable> <option>--snapshot</option>
 </screen>
    <para>
-   After testing you can remove the snapshot header by a final &gbp-dch; call:
+   After testing, you can remove the snapshot header by a final &gbp-dch; call:
    </para>
 <screen>
 &gbp-dch; <option>--since</option>=<replaceable>HEAD</replaceable> <option>--release</option>
@@ -58,12 +58,12 @@ git-buildpackage (0.3.7~1.gbp470ce2) UNRELEASED; urgency=low
    This will add no further entries but simply remove the specially crafted
    version number and the snapshot header. Again you can use any commit id
    or tag instead of <option>HEAD</option> if you want to add further changelog
-   entries - or you can (of course) use <option>--auto</option> again.
+   entries&mdash;or you can (of course) use <option>--auto</option> again.
    </para>
 <sect1 id="gbp.release.numbers">
     <title>Customizing snapshot numbers</title>
-    <para>If the auto incrementing of the snapshot number doesn't suite you needs you
-    can give any python expression that evaluates to a positive integer to
+    <para>If the auto incrementing of the snapshot number doesn't suite you needs, you
+    can give any Python expression that evaluates to a positive integer to
     calculate the new snapshot number:</para>
 <screen>
 &gbp-dch; <option>-S</option> <option>-a</option> <option>--snapshot-number</option>=<replaceable>1</replaceable>
@@ -82,11 +82,11 @@ snapshot-number = os.popen("git-log --pretty=oneline | wc -l").readlines()[0]
 <sect1 id="gbp.release.commit">
     <title>More on commit messages</title>
     <para>You can use <option>--full</option> to include the full commit
-    message in the changelog, note that you will lose the formatting though,
+    message in the changelog; note that you will lose the formatting though,
     since &dch; wraps lines by itself.</para>
-    <para>Additionally there are tags <option>Closes:</option> and
+    <para>Additionally, there are tags <option>Closes:</option> and
 <option>Thanks:</option> available to customize the commit message. Each tag
-has to start at the beginning of a single line. For example the git commit message
+has to start at the beginning of a single line. For example, the git commit message
 <screen>
 New upstream version
 
@@ -103,13 +103,13 @@ You can use the <option>Closes:</option> tag multiple times.
 There are several tags to further customize what (and how) commit messages get
 included into the changelog:
 </para><para>
-To exclude a commit from the generated changelog use:
+To exclude a commit from the generated changelog, use:
 </para><para>
 <screen>
 Gbp-Dch: Ignore
 </screen>
 This is e.g. useful if you're just fixing up a previous commit and couldn't
-amend it or for other janitorial commits that really don't need to end up in
+amend it, or for other janitorial commits that really don't need to end up in
 the changelog. For example, the following git commit message
 <screen>
 Set correct branchnames in debian/gbp.conf
@@ -119,25 +119,25 @@ Gbp-Dch: Ignore
 will not show up in the generated changelog in any way.
 </para>
 <para>
-To include the full commit message in the changelog use:
+To include the full commit message in the changelog, use:
 <screen>
 Gbp-Dch: Full
 </screen>
 </para>
 <para>
-To only include the short description in the changelog and skip the body use:
+To only include the short description in the changelog and skip the body, use:
 <screen>
 Gbp-Dch: Short
 </screen>
 The latter only takes effect when running &gbp-dch; with the
-<option>--full</option> option, since including only the short
+<option>--full</option> option since including only the short
 description is the default.
 </para>
 <para>
-Usually changelog entries should correspond to a single &git; commit. In this case it's
+Usually, changelog entries should correspond to a single &git; commit. In this case, it's
 convenient to include the commit id in the changelog entry. 
 This has the advantage that it's easy for people to identify changes without
-having to write very extensive changelog messages - the link back to &git; can be
+having to write very extensive changelog messages&mdash;the link back to &git; can be
 automated via the <option>Vcs-Browser</option> and <option>Vcs-Git</option>
 fields in <filename>debian/control</filename>. See <ulink url="https://honk.sigxcpu.org/cl2vcs">
 Cl2vcs</ulink> for how this looks.

--- a/docs/chapters/special.sgml
+++ b/docs/chapters/special.sgml
@@ -2,7 +2,7 @@
     <title>Special use cases</title>
     <sect1 id="gbp.special.dfsgfree">
     <title>Handling non-DFSG clean upstream sources</title>
-    <para>If you have to handle non DFSG clean upstream sources you can use a
+    <para>If you have to handle non-DFSG clean upstream sources, you can use a
     different branch which you have to create once:
     </para>
     <screen>
@@ -22,7 +22,7 @@
 &gitcmd; <option>tag</option> 10.4
     </screen>
     <para>
-    After the import you can switch to the <emphasis>dfsg_clean</emphasis>
+    After the import, you can switch to the <emphasis>dfsg_clean</emphasis>
     branch and get the newly imported changes from the upstream branch:
     </para>
     <screen>
@@ -43,14 +43,14 @@ cleanup-script.sh
     <sect1 id="gbp.special.nmus">
     <title>Importing NMUs</title>
     <para>
-    First create a branch that holds the NMUs from the tip of your
+    First, create a branch that holds the NMUs from the tip of your
     <option>debian-branch</option> (default is <emphasis>master</emphasis>) once:
     </para>
     <screen>
 &gitcmd; <option>branch</option> <replaceable>nmu</replaceable> <replaceable>master</replaceable>
     </screen>
     <para>
-    To import an NMU change into the git repository and use &gbp-import-dsc;:
+    To import an NMU, change into the git repository and use &gbp-import-dsc;:
     </para>
     <screen>
 &gitcmd; checkout <replaceable>master</replaceable>
@@ -68,7 +68,7 @@ cleanup-script.sh
     <title>Using &pbuilder;</title>
     <para>
     Since &pbuilder; uses different command line arguments than
-    &debuild; and &dpkg-buildpackage; we can't simply pass the options on the
+    &debuild; and &dpkg-buildpackage;, we can't simply pass the options on the
     command line but have to wrap them in the <option>--git-builder</option>
     option instead. <command>git-pbuilder</command> helps you with that:
 
@@ -76,7 +76,7 @@ cleanup-script.sh
 <command>git-buildpackage</command> <option>--git-builder="git-pbuilder"</option>  <option>--git-cleaner="fakeroot debian/rules clean"</option>
 </programlisting>
 
-    Note that we also used a different clean command since since &pdebuildcmd;
+    Note that we also used a different clean command since &pdebuildcmd;
     <option>clean</option> means something different than &debuildcmd;
     <option>clean</option>.
     
@@ -94,19 +94,19 @@ builder = /usr/bin/git-pbuilder
 
 	<command>git-pbuilder</command> defaults to building a package for the
 	<envar>sid</envar> distribution. If you want to build for another
-	distribution pass this in the <envar>DIST</envar> environment variable.
+	distribution, pass this in the <envar>DIST</envar> environment variable.
 
 	Invoking &gbp-buildpackage; will now invoke &pdebuildcmd; by
-	default and all additional command line arguments are passed to
+	default, and all additional command line arguments are passed to
 	<command>dpkg-buildpackage</command>. If you want to use
 	<command>debuild</command> again (without modifying
-	<filename>~/.gbp.conf</filename>) you can use:
+	<filename>~/.gbp.conf</filename>), you can use:
 <programlisting>
 <command>git-buildpackage</command> --git-builder=debuild
 </programlisting>
 
 	Furthermore, if you don't want this for all your invocations of
-	&gbp-buildpackage; you can use <filename>.git/gbp.conf</filename> in
+	&gbp-buildpackage;, you can use <filename>.git/gbp.conf</filename> in
 	one of your &git; repositories instead of
 	<filename>~/.gbp.conf</filename>.
     </para>
@@ -115,7 +115,7 @@ builder = /usr/bin/git-pbuilder
     <sect1 id="gbp.special.hacking">
     <title>Working on random packages</title>
     <para>
-    Whenever you need to work on an arbitrary &debian; package you can check it
+    Whenever you need to work on an arbitrary &debian; package, you can check it
     right into &git; with one command:
 <programlisting>
 git-import-dsc --download <filename>package</filename>
@@ -130,7 +130,7 @@ git-branch debian
     <emphasis>master</emphasis>). The second command
     creates a branch called <emphasis>debian</emphasis>. Now you can easily
     modify the package, revert changes you made, create other branches for
-    testing, see what changes you made, etc..  When finished just do</para>
+    testing, see what changes you made, etc.  When finished, just do</para>
 <programlisting>
 git-commit -a
 git-diff debian --
@@ -138,13 +138,13 @@ git-diff debian --
     <para>
 
     to get a nice patch that can be submitted to the &debian; BTS. You can also
-    fetch the source package from an URL:
+    fetch the source package from a URL:
 
 <programlisting>
 git-import-dsc --download <filename>http://mentors.debian.net/debian/pool/main/i/ipsec-tools/ipsec-tools_0.7.3-9.dsc</filename>
 </programlisting>
 
-   The import works incrementally, you can import new versions on top of
+   The import works incrementally; you can import new versions on top of
    already imported ones for e.g. easy review of changes.
     </para>
     </sect1>

--- a/docs/common.ent
+++ b/docs/common.ent
@@ -5,17 +5,17 @@
   <!ENTITY dhemail     		"<email>agx@sigxcpu.org</email>">
   <!ENTITY dhusername  		"Guido Guenther">
 
-  <!ENTITY gbp-buildpackage 	"<command>gbp buildpackage</command>">
-  <!ENTITY gbp-import-orig	"<command>gbp import-orig</command>">
-  <!ENTITY gbp-import-dsc	"<command>gbp import-dsc</command>">
-  <!ENTITY gbp-import-dscs	"<command>gbp import-dscs</command>">
-  <!ENTITY gbp-config		"<command>gbp config</command>">
-  <!ENTITY gbp-dch		"<command>gbp dch</command>">
+  <!ENTITY gbp-buildpackage 	"<command>gbp&nbsp;buildpackage</command>">
+  <!ENTITY gbp-import-orig	"<command>gbp&nbsp;import-orig</command>">
+  <!ENTITY gbp-import-dsc	"<command>gbp&nbsp;import-dsc</command>">
+  <!ENTITY gbp-import-dscs	"<command>gbp&nbsp;import-dscs</command>">
+  <!ENTITY gbp-config		"<command>gbp&nbsp;config</command>">
+  <!ENTITY gbp-dch		"<command>gbp&nbsp;dch</command>">
   <!ENTITY gbp		        "<command>gbp</command>">
-  <!ENTITY gbp-pull		"<command>gbp pull</command>">
-  <!ENTITY gbp-clone		"<command>gbp clone</command>">
-  <!ENTITY gbp-pq		"<command>gbp pq</command>">
-  <!ENTITY gbp-create-remote-repo "<command>gbp create-remote-repo</command>">
+  <!ENTITY gbp-pull		"<command>gbp&nbsp;pull</command>">
+  <!ENTITY gbp-clone		"<command>gbp&nbsp;clone</command>">
+  <!ENTITY gbp-pq		"<command>gbp&nbsp;pq</command>">
+  <!ENTITY gbp-create-remote-repo "<command>gbp&nbsp;create-remote-repo</command>">
   <!ENTITY git-pbuilder		"<command>git pbuilder</command>">
   <!ENTITY gitcmd		"<command>git</command>">
   <!ENTITY gitkcmd		"<command>gitk</command>">
@@ -30,9 +30,9 @@
   <!ENTITY rpm-email            "<email>markus.lehtonen@linux.intel.com</email>">
   <!ENTITY rpm-username         "Markus Lehtonen">
   <!ENTITY rpm-mansection       "<manvolnum>1</manvolnum>">
-  <!ENTITY gbp-buildpackage-rpm "<command>gbp buildpackage-rpm</command>">
-  <!ENTITY gbp-import-srpm      "<command>gbp import-srpm</command>">
-  <!ENTITY gbp-pq-rpm           "<command>gbp pq-rpm</command>">
+  <!ENTITY gbp-buildpackage-rpm "<command>gbp&nbsp;buildpackage-rpm</command>">
+  <!ENTITY gbp-import-srpm      "<command>gbp&nbsp;import-srpm</command>">
+  <!ENTITY gbp-pq-rpm           "<command>gbp&nbsp;pq-rpm</command>">
   <!ENTITY rpmbuild             "<command>rpmbuild</command>">
   <!ENTITY wget                 "<command>wget</command>">
 

--- a/docs/manpages/gbp-config.sgml
+++ b/docs/manpages/gbp-config.sgml
@@ -45,7 +45,7 @@
   <refsect1>
     <title>EXIT CODES</title>
     <para>
-    When &gbp-config; finishes it indicates success or failure with its exit code:
+    When &gbp-config; finishes, it indicates success or failure with its exit code:
     </para>
     <variablelist>
       <varlistentry>
@@ -76,7 +76,7 @@
     $ gbp config buildpackage.upstream-branch
     buildpackage.upstream-branch=upstream
     </screen>
-    <para>Print the values of all of &gbp-buildpackage;s options</para>
+    <para>Print the values of all of &gbp-buildpackage; options</para>
     <screen>
     $ gbp config buildpackage
     buildpackage.upstream-branch=upstream

--- a/docs/manpages/gbp-create-remote-repo.sgml
+++ b/docs/manpages/gbp-create-remote-repo.sgml
@@ -39,11 +39,11 @@
     tracking so you can use &gbp-pull; to update your repository from there.
     </para>
     <para>
-      Before performing any action on the remote location it will print the 
+      Before performing any action on the remote location, it will print the
       remote URL and ask for confirmation.
     </para>
     <para>
-    Note: By default the remote repositories are created in the <systemitem
+    Note: By default, the remote repositories are created in the <systemitem
     class="groupname">collab-maint</systemitem> repository on <systemitem
     class="systemname">git.debian.org</systemitem>.
     </para>

--- a/docs/manpages/gbp-dch.sgml
+++ b/docs/manpages/gbp-dch.sgml
@@ -64,17 +64,17 @@
     <title>DESCRIPTION</title>
     <para>
     &gbp-dch; reads git commit messages and generates the &debian; changelog from
-    it. If no arguments are given &gbp-dch; starts from the last tagged Debian
+    it. If no arguments are given, &gbp-dch; starts from the last tagged Debian
     package version up to the current tip of the current branch. If the
     distribution of the topmost section in
-    <filename>debian/changelog</filename> is <emphasis>UNRELEASED</emphasis>
-    the changelog entries will be inserted into this section. Otherwise a new
+    <filename>debian/changelog</filename> is <emphasis>UNRELEASED</emphasis>,
+    the changelog entries will be inserted into this section. Otherwise, a new
     section will be created.
     </para>
     <para>
-    If <option>--auto</option> is given &gbp-dch; tries to guess the
+    If <option>--auto</option> is given &gbp-dch;, tries to guess the
     last &git; commit documented in the changelog - this only works in snapshot
-    mode. Otherwise <option>--since</option> can be used to tell &gbp-dch;
+    mode. Otherwise, <option>--since</option> can be used to tell &gbp-dch;
     at which point it should start in the &git; history.
     </para>
     <para>
@@ -83,8 +83,8 @@
     <emphasis>debian/</emphasis> is a good choice if upstream uses &git; and
     all Debian packaging changes are restricted to the
     <replaceable>debian/</replaceable> subdir. In more sophisticated cases
-    (like backports) you can use <option>--git-log</option> to restrict the
-    generated changelog entries further. E.g. by using
+    (like backports), you can use <option>--git-log</option> to restrict the
+    generated changelog entries further, e.g. by using
     <option>--git-log=</option><replaceable>"--author=Foo Bar"</replaceable>.
     </para>
   </refsect1>
@@ -179,7 +179,7 @@
         <listitem>
           <para>
           What meta tags to look for to generate bug-closing changelog entries.
-          The default is 'Closes|LP' to support Debian and Launchpad.
+          The default is <literal>'Closes|LP'</literal> to support Debian and Launchpad.
           </para>
         </listitem>
       </varlistentry>
@@ -189,19 +189,22 @@
         <listitem>
           <para>
           What regular expression should be used to parse out the bug number.
-          The default is '(?:bug|issue)?\#?\s?\d+'. Note: the regex should
+          The default is <literal>'(?:bug|issue)?\#?\s?\d+'</literal>. Note: the regex should
           suppress all portions of the bug number that are not wanted using
-          "(?:)", see pyhton regex manual for details.
+          <literal>"(?:)"</literal>, see Python regex manual for details.
+          </para>
+          <para>
           Example:
-              --meta-closes-bugnum="(?:bug)?\s*ex-\d+"
+              <option>--meta-closes-bugnum=</option><literal>"(?:bug)?\s*ex-\d+"</literal>
 
               would match all of the following:
+          <screen>
                  Possible Txt  Match?    Result
                  ------------  ------    ------
                  bug EX-12345    Y       EX-12345
                  ex-01273        Y       ex-01273
                  bug ex-1ab      Y       ex-1
-                 EX--12345       N
+                 EX--12345       N</screen>
           </para>
         </listitem>
       </varlistentry>
@@ -241,7 +244,7 @@
         <listitem>
           <para>
           Remove any snapshot release banners and version suffixes, set
-          the current distribution to <replaceable>unstable</replaceable> and
+          the current distribution to <replaceable>unstable</replaceable>, and
           open the changelog for final tweaking.
           </para>
         </listitem>
@@ -254,7 +257,7 @@
           <para>
           Add a new changelog section with version
           <replaceable>newversion</replaceable>. Together with
-          <option>--snapshot</option> the snapshot number will be appended to
+          <option>--snapshot</option>, the snapshot number will be appended to
           <replaceable>newversion</replaceable>.
           </para>
         </listitem>
@@ -424,14 +427,14 @@
     having to worry about version numbers or changelog entries.
     </para>
     <para>
-    When using <option>--snapshot</option> or <option>-S</option> &gbp-dch;
+    When using <option>--snapshot</option> or <option>-S</option>, &gbp-dch;
     uses a pseudo header in the Debian changelog to remember the last git
     commit it added a changelog entry for. It also sets a version number
     ending in
     <replaceable>~&lt;snaspshotnumber&gt;.gbp&lt;commitid&gt;</replaceable>.
     It automatically increments the snapshot number on subsequent invocations
     of &gbp-dch; <option>-S</option> so that later snapshots automatically
-    have a higher version number. To leave snapshot mode invoke &gbp-dch;
+    have a higher version number. To leave snapshot mode, invoke &gbp-dch;
     with the <option>--release</option> option. This removes the pseudo
     header and unmangles the version number so the released version has a
     higher version number than the snapshots.
@@ -440,7 +443,7 @@
   <refsect1>
     <title>META TAGS</title>
     <para>
-    Additional to the above options the formatting of the commit message
+    Additional to the above options, the formatting of the commit message
     in <filename>debian/changelog</filename> can be modified by special tags
     (called Meta Tags)
     given in the git commit message. Meta Tag processing can be activated via
@@ -462,7 +465,7 @@
             <replaceable>Short</replaceable> which will only use the
             description (the first line) of the commit message when
             generating the changelog entry (useful
-            when <option>--full</option> is given) and
+            when <option>--full</option> is given), and
             <replaceable>Full</replaceable> which will use the full
             commit message when generating the changelog entry (useful
             when <option>--full</option> is not given).

--- a/docs/manpages/gbp-import-dsc.sgml
+++ b/docs/manpages/gbp-import-dsc.sgml
@@ -53,11 +53,11 @@
     &gbp-import-dsc; imports a &debian; source package into a &git; repository,
     notes the package version in the commit logs, and commits the change. All
     information, including package name, version, &debian;  diffs, and upstream
-    source is automatically detected from the source package.
+    source, is automatically detected from the source package.
     </para>
     <para>
-    If the command is run from within an existing repository it will import
-    into this, if not a new repository named as the Debian source package is
+    If the command is run from within an existing repository, it will import
+    into this; if not, a new repository named as the Debian source package is
     created.
     </para>
   </refsect1>
@@ -160,7 +160,7 @@
           <para>
           Download the source package instead of looking for it in the local
           file system. The argument can either be a
-          <replaceable>source-package</replaceable> name or an
+          <replaceable>source-package</replaceable> name or a
           <replaceable>URL</replaceable>. The former uses &apt-get; to download
           the source while the later uses &dget;.
           </para>
@@ -180,7 +180,7 @@
         </term>
         <listitem>
           <para>
-          Allow to import a package with the same debian version.
+          Allow one to import a package with the same debian version.
           </para>
         </listitem>
       </varlistentry>

--- a/docs/manpages/gbp-import-dscs.sgml
+++ b/docs/manpages/gbp-import-dscs.sgml
@@ -40,12 +40,12 @@
     <title>DESCRIPTION</title>
     <para>
     &gbp-import-dscs; imports several versions of a Debian source package into
-    a &git; repository. To do so it sorts the packages by their versions first
+    a &git; repository. To do so, it sorts the packages by their versions first,
     and then imports them via calling &gbp-import-dsc; on each package. 
     </para> 
 
     <para>
-    If the current directory isn't a &git; repository already the repository is
+    If the current directory isn't a &git; repository already, the repository is
     created in a subdir of the current working directory, named after the first
     imported package, otherwise the &git; repository in the current working
     directory is being used. This allows for incremental imports.
@@ -66,7 +66,7 @@
         </term>
         <listitem>
 	  <para>Ignore <filename>gbp.conf</filename> files stored in the git
-repository itself. This can be useful to ignore branch informations and other
+repository itself. This can be useful to ignore branch information and other
 options shipped in the package source.</para>
         </listitem>
       </varlistentry>

--- a/docs/manpages/gbp-import-orig.sgml
+++ b/docs/manpages/gbp-import-orig.sgml
@@ -48,12 +48,12 @@
     <para>
     &gbp-import-orig; imports <replaceable>upstream-source</replaceable> into
     the &git; repository. <replaceable>upstream-source</replaceable> can either
-    be a gzip, bzip2, lzma or xz compressed tar archive, a zip archive or an
+    be a gzip, bzip2, lzma or xz compressed tar archive, a zip archive, or an
     already unpacked source tree. If it is already of the form
     <replaceable>package-name_version.orig.tar.gz</replaceable>, the version
-    information is read from the tarball's filename otherwise it can be given
+    information is read from the tarball's filename, otherwise it can be given
     on the command line via <option>--upstream-version</option>.  If the source
-    package name or version can't be determined &gbp-import-orig; will prompt
+    package name or version can't be determined, &gbp-import-orig; will prompt
     for it unless <option>--no-interactive</option> is given.
     </para>
     <para>
@@ -138,7 +138,7 @@
           <para>
           Add <replaceable>tag-format</replaceable> as additional parent to the
           commit of the upstream tarball. Useful when upstream uses git and you
-          want to link to it's revision history. The
+          want to link to its revision history. The
           <replaceable>tag-format</replaceable> can be a pattern similar to
           what <option>--upstream-tag</option> supports.
           </para>
@@ -206,7 +206,7 @@
         </term>
         <listitem>
           <para>
-          if using a filter also filter the files out of the tarball
+          if using a filter, also filter the files out of the tarball
           passed to <command>pristine-tar</command>
           </para>
         </listitem>
@@ -270,7 +270,7 @@
       &gbp-import-orig; --uscan
     </screen>
     <para>
-    After downloading an upstream tarball by hand import it
+    After downloading an upstream tarball by hand, import it
     </para>
     <screen>
       &gbp-import-orig; ../upstream-tarball-0.1.tar.gz

--- a/docs/manpages/gbp-import-srpm.sgml
+++ b/docs/manpages/gbp-import-srpm.sgml
@@ -174,9 +174,9 @@
         </term>
         <listitem>
           <para>
-          Allow to re-import a package with an already existing version. This
-          will not re-import the upstream sources - only packaging files will
-          be re-imported.
+          Allow one to re-import a package with an already existing version.
+          This will not re-import the upstream sources - only packaging files
+          will be re-imported.
           </para>
         </listitem>
       </varlistentry>

--- a/docs/manpages/gbp-pq.sgml
+++ b/docs/manpages/gbp-pq.sgml
@@ -43,10 +43,10 @@
     <para>
     &gbp-pq; helps one to manage quilt patches in &debian; packages that are
     maintained with &gbp;. This is especially useful with packages using the
-    3.0 (quilt) source format. With &gbp-pq; you can maintain the quilt patches
+    3.0 (quilt) source format. With &gbp-pq;, you can maintain the quilt patches
     that should be applied to a package on a separate branch called patch-queue
     branch. So if your &debian; package lives on
-    <replaceable>master</replaceable> the associated patch-queue branch will be
+    <replaceable>master</replaceable>, the associated patch-queue branch will be
     called <replaceable>patch-queue/master</replaceable>.
     </para>
     <para>
@@ -95,7 +95,7 @@
         <listitem>
           <para>
           Drop (delete) the patch queue associated to the current branch. So if
-          you're on branch <replaceable>foo</replaceable> this would drop
+          you're on branch <replaceable>foo</replaceable>, this would drop
           branch <replaceable>patch-queue/foo</replaceable>.
           </para>
         </listitem>
@@ -183,7 +183,7 @@
         </term>
         <listitem>
           <para>
-          When importing a patch queue fails, go back commit by commit on the
+          When importing a patch queue fails, go back commit-by-commit on the
           current branch to check if the patch-queue applies there. Do this at
           most <replaceable>NUM</replaceable> times. This can be useful if the
           patch-queue doesn't apply to the current branch HEAD anymore, e.g.
@@ -201,7 +201,7 @@
       <varlistentry>
         <term><option>--force</option></term>
         <listitem>
-          <para>In case of import even import if the branch already
+          <para>In case of <option>import</option>, import even if the branch already
             exists</para>
         </listitem>
       </varlistentry>
@@ -212,7 +212,7 @@
           <para>
           What meta tags to look for to generate a commit message when
           using <option>export</option> <option>--commit</option>.
-          The default is 'Closes|LP' to support Debian and Launchpad.
+          The default is <literal>'Closes|LP'</literal> to support Debian and Launchpad.
           </para>
         </listitem>
       </varlistentry>
@@ -224,8 +224,8 @@
             What regular expression should be used to parse out the
             bug number when using
 	    <option>export</option> <option>--commit</option>.  The
-            default is '(?:bug|issue)?\#?\s?\d+'. For details see
-	    <xref linkend="man.gbp.dch">.
+            default is <literal>'(?:bug|issue)?\#?\s?\d+'</literal>.
+            See <xref linkend="man.gbp.dch"> for details.
           </para>
         </listitem>
       </varlistentry>
@@ -234,7 +234,7 @@
   <refsect1>
     <title>TAGS</title>
     <para>
-    When exporting patches from a patch-queue branch &gbp-pq; will look at the
+    When exporting patches from a patch-queue branch, &gbp-pq; will look at the
     patch header for special tags it recognizes. All tags need to start at the
     first column and require at least one whitespace after the colon.
     </para>
@@ -255,7 +255,7 @@
           <para>
 	    The name to use for the patch when running
 	    <screen>&gbp-pq; export</screen>
-	    If unset it will be formatted like
+	    If unset, it will be formatted like
 	    <command>git am</command> would format it.
           </para>
         </listitem>

--- a/docs/manpages/gbp-pull.sgml
+++ b/docs/manpages/gbp-pull.sgml
@@ -103,7 +103,7 @@
   <refsect1>
     <title>EXIT CODES</title>
     <para>
-    When &gbp-pull; finishes it indicates success or failure with it's exit code:
+    When &gbp-pull; finishes, it indicates success or failure with its exit code:
     </para>
     <variablelist>
       <varlistentry>

--- a/docs/manpages/gbp.conf.sgml
+++ b/docs/manpages/gbp.conf.sgml
@@ -52,8 +52,8 @@
       precedence.
     </para>
     <para>
-      Each file consists of either zero or one default section and
-      zero or one sections for each &gbp; command. Additionally there
+      Each file consists of either zero or one default section, and
+      zero or one sections for each &gbp; command. Additionally, there
       can be an arbitrary number of
       <option>remote-config</option> sections.  Comments start with a
       hash sign (<option>#</option>). The syntax is:
@@ -75,16 +75,16 @@
 <para>
   The sections for each command are named like the command (without &gbp;) surrounded
   by square brackets (e.g. <option>[buildpackage]</option>).
-  For backwards compatibility command sections starting with <filename>git-</filename> or
+  For backwards compatibility, command sections starting with <filename>git-</filename> or
   <filename>gbp-</filename> are also supported but will provoke a warning when parsed by
   &gbp;.
 </para>
 
 <para>
   The <option>key=value</option> pairs of the command sections are
-  named like the command line options of the corresponding command
+  named like the command-line options of the corresponding command
   with the '--' stripped off and can hold the same values (but see
-  below for details). For example
+  below for details). For example,
   the <xref linkend="man.gbp.buildpackage"> manual page documents
   the <option>--git-export-dir</option>=<parameter>directory</parameter>
   option which can be turned into configuration file setting by
@@ -98,8 +98,8 @@
 </programlisting>
 
 <para>
-  Options that can be repeated on the command line take Python like
-  lists in the config file. For example
+  Options that can be repeated on the command line take Python-like
+  lists in the config file. For example,
   the <xref linkend="man.gbp.import.orig"> commmand has the
   <option>--filter</option>=<parameter>pattern</parameter> option
   which can be turned into a configuration file option like this:
@@ -111,8 +111,8 @@
 </programlisting>
 
 <para>
-Boolean options can be either <option>True</option> or <option>False</option>. For example
-<xref linkend="man.gbp.import.orig">; has the <option>--pristine-tar</option> and
+Boolean options can be either <option>True</option> or <option>False</option>. For example,
+<xref linkend="man.gbp.import.orig"> has the <option>--pristine-tar</option> and
 <option>--no-pristine-tar</option> options which translate to:
 </para>
 <programlisting>
@@ -130,19 +130,19 @@ Boolean options can be either <option>True</option> or <option>False</option>. F
 <note>
 <para>
   To see the current set of values that would be applied after parsing the
-  configuration files use <xref linkend="man.gbp.config">.
+  configuration files, use <xref linkend="man.gbp.config">.
 </para>
 </note>
 <note>
 <para>
  <command>gbp import-dscs</command> and <command>git-pbuilder</command>
-can't be configured via gbp.conf.
+can't be configured via <filename>gbp.conf</filename>.
 </para>
 </note>
 
 <para>
 <xref linkend="man.gbp.create.remote.repo"> can additionally parse remote site
-configurations from <filename>gbp.conf</filename>. For example a configuration like:
+configurations from <filename>gbp.conf</filename>. For example, a configuration like:
 </para>
 
 <programlisting>
@@ -154,7 +154,7 @@ template-dir = /srv/alioth.debian.org/chroot/home/groups/pkg-libvirt/git-templat
 </programlisting>
 
 <para>
-Can be used to create remote repositories for the pkg-libvirt project using:
+can be used to create remote repositories for the pkg-libvirt project using:
 </para>
 
 <programlisting>
@@ -212,7 +212,7 @@ An example set up for packaging work:
   <title>ENVIRONMENT</title>
    <variablelist>
       <varlistentry>
-      <term>GBP_CONF_FILES</term>
+      <term><envar>GBP_CONF_FILES</envar></term>
       <listitem><para>Colon separated list of files to parse. The default is
 the above list of configuration files.</para></listitem>
       </varlistentry>

--- a/docs/manpages/gbp.sgml
+++ b/docs/manpages/gbp.sgml
@@ -62,7 +62,7 @@
   <refsect1>
     <title>GBP COMMANDS</title>
     <para>
-      These are the possible commands. For possible arguments to these commands please
+      These are the possible commands. For possible arguments to these commands, please
       see the corresponding man pages.
     </para>
     <variablelist>

--- a/docs/manpages/man.common-options.ent
+++ b/docs/manpages/man.common-options.ent
@@ -54,7 +54,8 @@
           COLOR_SCHEME is
           '&lt;debug&gt;:&lt;info&gt;:&lt;warning&gt;:&lt;error&gt;'.
           Numerical values and color names are accepted, empty fields imply
-          the default color. For example --git-color-scheme='cyan:34::' would
+          the default color. For example,
+          <option>--git-color-scheme=</option><literal>'cyan:34::'</literal> would
           show debug messages in cyan, info messages in blue and other messages
           in default (i.e. warning and error messages in red).
           </para>

--- a/docs/manpages/man.conffiles.sgml
+++ b/docs/manpages/man.conffiles.sgml
@@ -1,4 +1,4 @@
     <title>CONFIGURATION FILES</title>
     <para>Several <filename>gbp.conf</filename> files are parsed 
-    to set defaults for the above commandline arguments. See the
+    to set defaults for the above command-line arguments. See the
     <xref linkend="man.gbp.conf"> manpage for details.</para>


### PR DESCRIPTION
in hopes of improving readability.  Changes include:

* Correct spelling
* Correct usage of "its" vs "it's"
* Add commas where appropriate, e.g. where a subordinate clause
  is at the beginning of a sentence
* Add tags like `<option>`, `<literal>`, `<filename>` where appropriate
* Add `&nbsp;` for gbp subcommands to avoid them from being split
  across two lines
* Fix layout of `--meta-closes-bugnum=` in `manpages/gbp-dch.sgml`