### PR TITLE
Restore coloured background for <programlisting> in docs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -32,6 +32,7 @@ all: $(MANUAL) $(MANPAGES)
 
 $(MANUAL): manual.sgml chapters/*.sgml manpages/*.sgml
 	docbook-2-html -s local $<
+	sed -i 's/^CLASS="[A-Z0-9]\+"/\L&/' manual-html/*.html
 	cp /usr/share/gtk-doc/data/*.png $(MANUAL)
 
 # We build manpages under 'buildxref/' just to get an updated cross-reference


### PR DESCRIPTION
The git-buildpackage documentation contains a special coloured-background CSS style from GTK-Doc for `.programlisting`, but Modular DocBook HTML Stylesheet generates HTML code, even class names, in all uppercase form, which does not matches the lowercase class names in CSS in modern browser.

This patch runs a `sed` command to change the class names to all lowercase to provide a quick workaround.

----

Do you think it would be a good idea to migrate to DocBook v5.0 XML, as recommended by the GTK-Doc folks at http://www.gtk.org/gtk-doc/requirements.php ?  I think DocBook XML, with its access to modern tools, would make git-buildpackage documentation look a lot better.  :-)