### PR TITLE
use git rev-parse --git-dir instead of just .git/

### DIFF
--- a/gbp/scripts/common/buildpackage.py
+++ b/gbp/scripts/common/buildpackage.py
@@ -19,6 +19,7 @@
 """Common functionality for Debian and RPM buildpackage scripts"""
 
 import os, os.path
+import subprocess
 import pipes
 import tempfile
 import shutil
@@ -31,7 +32,9 @@ index_name = "INDEX"
 # when we want to reference the working copy in treeish context we call it:
 wc_name = "WC"
 # index file name used to export working copy
-wc_index = ".git/gbp_index"
+pipe = subprocess.Popen(["git", "rev-parse", "--git-dir"], shell=False, stdout=subprocess.PIPE)
+gitdir = pipe.stdout.readline().strip()
+wc_index = os.path.join(gitdir, "gbp_index")
 
 
 def sanitize_prefix(prefix):

--- a/gbp/scripts/pq.py
+++ b/gbp/scripts/pq.py
@@ -20,6 +20,7 @@
 from six.moves import configparser
 import errno
 import os
+import subprocess
 import shutil
 import sys
 import tempfile
@@ -214,7 +215,7 @@ def export_patches(repo, branch, options):
 def save_patches(series):
     """
     Save the current patches in a temporary directory
-    below .git/
+    below gitdir, which is usually .git/
 
     @param series: path to series file
     @return: tmpdir and path to saved series file
@@ -224,7 +225,9 @@ def save_patches(series):
     src = os.path.dirname(series)
     name = os.path.basename(series)
 
-    tmpdir = tempfile.mkdtemp(dir='.git/', prefix='gbp-pq')
+    pipe = subprocess.Popen(["git", "rev-parse", "--git-dir"], shell=False, stdout=subprocess.PIPE)
+    gitdir = pipe.stdout.readline().strip()
+    tmpdir = tempfile.mkdtemp(dir=gitdir, prefix='gbp-pq')
     patches = os.path.join(tmpdir, 'patches')
     series = os.path.join(patches, name)
 

--- a/gbp/scripts/pq.py
+++ b/gbp/scripts/pq.py
@@ -211,13 +211,13 @@ def export_patches(repo, branch, options):
         drop_pq(repo, branch)
 
 
-def safe_patches(series):
+def save_patches(series):
     """
-    Safe the current patches in a temporary directory
+    Save the current patches in a temporary directory
     below .git/
 
     @param series: path to series file
-    @return: tmpdir and path to safed series file
+    @return: tmpdir and path to saved series file
     @rtype: tuple
     """
 
@@ -271,7 +271,7 @@ def import_quilt_patches(repo, branch, series, tries, force):
     # If we go back in history we have to safe our pq so we always try to apply
     # the latest one
     if len(commits) > 1:
-        tmpdir, series = safe_patches(series)
+        tmpdir, series = save_patches(series)
 
     queue = PatchSeries.read_series_file(series)
 

--- a/gbp/scripts/pq_rpm.py
+++ b/gbp/scripts/pq_rpm.py
@@ -208,7 +208,7 @@ def export_patches(repo, options):
     GitCommand('status')(['--', spec.specdir])
 
 
-def safe_patches(queue):
+def save_patches(queue):
     """
     Safe the current patches in a temporary directory
 
@@ -305,7 +305,7 @@ def import_spec_patches(repo, options):
                   recursive=False)
         spec.specdir = packaging_tmp
     in_queue = spec.patchseries()
-    queue = safe_patches(in_queue)
+    queue = save_patches(in_queue)
     # Do import
     try:
         gbp.log.info("Switching to branch '%s'" % pq_branch)


### PR DESCRIPTION
Sometimes git submodules have a redirection pointer in their .git instead of a directory.
This code (which should probably be refactored, migrated into a gitDir function, sanity checked, etc) addresses that issue.
See bug https://bugs.debian.org/674015
