### PR TITLE
Separate paths for SPECS and SOURCES

### DIFF
--- a/gbp/scripts/pq_rpm.py
+++ b/gbp/scripts/pq_rpm.py
@@ -143,7 +143,7 @@ def update_patch_series(repo, spec, start, end, options):
     rm_patch_files(spec)
 
     patches, commands = generate_patches(repo, start, end,
-                                         spec.specdir, options)
+                                         spec.sourcedir, options)
     spec.update_patches(patches, commands)
     spec.write_spec_file()
     return patches


### PR DESCRIPTION
If spec file was found in SPECS folder then it's
likely that sources are in a SOURCES directory, because
it's a common structure used by rpmbuild. To use it
correctly separate 'sourcedir' value should be
initialized and used to point to the place where sources
are located.
