### PR TITLE
Use tox for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.pyc
 .noseids
 .coverage
+.tox/
 .ropeproject/
 coverage.xml
 gbp/version.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+six>=1.9.0
+nose>=0.11.1
+coverage>=2.85
+nosexcover>=1.0.7
+python-dateutil
+mock

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,23 @@
+[tox]
+envlist = pep8, py27
+skipsdist = True
+
+[testenv]
+whitelist_externals =
+  find
+install_command = pip install {opts} {packages}
+deps = -r{toxinidir}/requirements.txt
+sitepackages = True
+commands =
+  find . -type f -name "*.pyc" -delete
+
+[testenv:pep8]
+deps = hacking
+commands =
+  find . -type f -name "*.pyc" -delete
+  flake8 {posargs}
+
+[testenv:py27]
+commands =
+  find . -type f -name "*.pyc" -delete
+  python setup.py nosetests --verbosity=3 --with-xcoverage {posargs}


### PR DESCRIPTION
tox is a tool to automate creating venv and running tests like py27 unittests and pep8 style checks.

This commit adds tox configs needed and some other files for this feature.

Requirements:
  apt-get install python-tox

Usage:
* Run unittests: **tox -e py27** 
* Run PEP8 tests (will fail because there is **a lot** of errors): **tox -e pep8**

Just to clarify - this it **not** to replace the way how tests are run during package build process. This is an additional tool that helps to run tests without building a package :)