### PR TITLE
Added option `never` to dch `--spawn-editor` choices

### DIFF
--- a/debian/git-buildpackage.zsh-completion
+++ b/debian/git-buildpackage.zsh-completion
@@ -157,7 +157,7 @@ _gbp-dch () {
 		'--git-author[Use git name configuration for changelog signature]' \
 		'(--multimaint-merge --no-multimaint-merge)--multimaint-merge[Merge commits by maintainer]' \
 		'(--multimaint-merge --no-multimaint-merge)--multimaint-merge[Do not merge commits by maintainer]' \
-		'--spawn-editor=[Spawn an editor]:when:(always snapshot release)' \
+		'--spawn-editor=[Spawn an editor]:when:(always never snapshot release)' \
 		'--commit-msg=[Commit message format string]' \
 		'--commit[Commit the generated changelog]' \
 		'*:Paths:_files -/'
@@ -402,7 +402,7 @@ _gbp-dch () {
 		'--git-author[Use git name configuration for changelog signature]' \
 		'(--multimaint-merge --no-multimaint-merge)--multimaint-merge[Merge commits by maintainer]' \
 		'(--multimaint-merge --no-multimaint-merge)--multimaint-merge[Do not merge commits by maintainer]' \
-		'--spawn-editor=[Spawn an editor]:when:(always snapshot release)' \
+		'--spawn-editor=[Spawn an editor]:when:(always never snapshot release)' \
 		'--commit-msg=[Commit message format string]' \
 		'--commit[Commit the generated changelog]' \
 		'*:Paths:_files -/'

--- a/docs/manpages/gbp-dch.sgml
+++ b/docs/manpages/gbp-dch.sgml
@@ -53,7 +53,7 @@
       <arg><option>--[no-]git-author</option></arg>
       <arg><option>--[no-]multimaint</option></arg>
       <arg><option>--[no-]multimaint-merge</option></arg>
-      <arg><option>--spawn-editor=[always|snapshot|release]</option></arg>
+      <arg><option>--spawn-editor=[always|never|snapshot|release]</option></arg>
       <arg><option>--commit-msg=</option><replaceable>msg-format</replaceable></arg>
       <arg><option>--commit</option></arg>
       <arg><option>--customizations=</option><replaceable>customization-file</replaceable></arg>
@@ -390,11 +390,11 @@
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><option>--spawn-editor=<replaceable>[always|snapshot|release]</replaceable></option>
+        <term><option>--spawn-editor=<replaceable>[always|never|snapshot|release]</replaceable></option>
         </term>
         <listitem>
           <para>
-          Whether to spawn an editor: always, when doing snapshots or when
+          Whether to spawn an editor: always, never, when doing snapshots or when
           doing a release.
           </para>
         </listitem>

--- a/gbp/scripts/dch.py
+++ b/gbp/scripts/dch.py
@@ -286,10 +286,10 @@ def process_editor_option(options):
     elif options.release:
         states.append("release")
 
-    if options.spawn_editor in states:
-        return "sensible-editor"
-    else:
+    if options.spawn_editor == 'never' or options.spawn_editor not in states:
         return None
+    else:
+        return "sensible-editor"
 
 
 def changelog_commit_msg(options, version):


### PR DESCRIPTION
Sometimes it's unnecessary to open editor after writing a changelog. Right now the only way to get such behaviour is to use the opposite option (use `--spawn-editor=snapshot` if we are making a release and vice versa). I guess it would be more convenient to have an option `--spawn-editor=never` for such case.