### PR TITLE
pq: pass '--no-merges' to git log

### DIFF
--- a/gbp/scripts/pq.py
+++ b/gbp/scripts/pq.py
@@ -73,7 +73,7 @@ def generate_patches(repo, start, end, outdir, options):
             raise GbpError('%s not a valid tree-ish' % treeish)
 
     # Generate patches
-    rev_list = reversed(repo.get_commits(start, end))
+    rev_list = reversed(repo.get_commits(start, end, options='--no-merges'))
     for commit in rev_list:
         info = repo.get_commit_info(commit)
         # Parse 'gbp-pq-topic:'


### PR DESCRIPTION
When we merge changes to patch-queue/master from another repo then **gbp pq export** generates TWO patches:
**First** patch from original commit, it's OK
**Second** patch from merge commit, and it reverts previous, so nothing will change when we build a package.

Passing **--no-merges** to git log when we do **gbp pq export** fixes the problem.