### PR TITLE
Use imperative form in git commit messages: import (not imported)

### DIFF
--- a/docs/manpages/gbp-import-orig.sgml
+++ b/docs/manpages/gbp-import-orig.sgml
@@ -179,7 +179,7 @@
           <para>
           use this format string for the commit message when importing upstream
           versions, default is
-          <replaceable>Imported Upstream version %(version)s</replaceable>
+          <replaceable>Import upstream version %(version)s</replaceable>
           </para>
         </listitem>
       </varlistentry>

--- a/gbp/config.py
+++ b/gbp/config.py
@@ -115,7 +115,7 @@ class GbpOptionParser(OptionParser):
                  'debian-tag'      : 'debian/%(version)s',
                  'debian-tag-msg'  : '%(pkg)s Debian release %(version)s',
                  'upstream-tag'    : 'upstream/%(version)s',
-                 'import-msg'      : 'Imported Upstream version %(version)s',
+                 'import-msg'      : 'Import upstream version %(version)s',
                  'commit-msg'      : 'Update changelog for %(version)s release',
                  'filter'          : [],
                  'snapshot-number' : 'snapshot + 1',


### PR DESCRIPTION
The convention in all git commits is to use imperative form, not
past tense. For example 'git merge' will make an automatic commit
like "Merge xyz", not "Merged xyz". Git-buildpackage should follow
this convention in this one default commit message string.

The other default commit messages are already correct.

Also spell upstream without a capital letter, which is unlike in German
the correct way in English.