### PR TITLE
find_version: add a missing decode

### DIFF
--- a/gbp/deb/git.py
+++ b/gbp/deb/git.py
@@ -95,6 +95,7 @@ class DebianGitRepository(PkgGitRepository):
             if ret:
                 return None
             for line in out:
+                line = line.decode()
                 if line.endswith(" %s\n" % version):
                     # dereference to a commit object
                     return self.rev_parse("%s^0" % legacy_tag)


### PR DESCRIPTION
_git_getoutput returns a list of bytes, that we need to decode