### PR TITLE
export_source: replace orig_file with source.upstream_tarball_name

### DIFF
--- a/gbp/scripts/buildpackage.py
+++ b/gbp/scripts/buildpackage.py
@@ -101,8 +101,8 @@ def export_source(repo, tree, source, options, dest_dir, tarball_dir):
         if source.is_native():
             raise GbpError("Cannot overlay Debian native package")
         extract_orig(os.path.join(tarball_dir,
-                                  du.orig_file(source,
-                                               options.comp_type)),
+                                  source.upstream_tarball_name(
+                                      options.comp_type)),
                      dest_dir)
 
     gbp.log.info("Exporting '%s' to '%s'" % (options.export, dest_dir))


### PR DESCRIPTION
orig_file was dropped in 8edd16022d75967a8fe54ef99a0733400a287bc2