### PR TITLE
rpm.SpecFile: support %autosetup

### DIFF
--- a/tests/20_test_rpm.py
+++ b/tests/20_test_rpm.py
@@ -334,6 +334,18 @@ class TestSpecFile(RpmTestBase):
         eq_(len(series), 2)
         eq_(os.path.basename(series[-1].path), '1.patch')
 
+    def test_patch_series_autosetup(self):
+        """Check patch series functionalitu with %autostup"""
+        spec_filepath = os.path.join(SPEC_DIR, 'gbp-test3.spec')
+        spec = SpecFileTester(spec_filepath)
+
+        eq_(len(spec.patchseries()), 2)
+        eq_(len(spec.patchseries(ignored=True)), 3)
+        spec.update_patches(['1.patch'], {})
+        eq_(len(spec.patchseries()), 1)
+        eq_(len(spec.patchseries(ignored=True)), 2)
+        eq_(spec.protected('_special_directives')['patch'], [])
+
     def test_patch_series_quirks(self):
         """Patches are applied in order different from the patch numbering"""
         spec_filepath = os.path.join(SPEC_DIR, 'gbp-test-quirks.spec')

--- a/tests/data/rpm/specs/gbp-test3.spec
+++ b/tests/data/rpm/specs/gbp-test3.spec
@@ -1,0 +1,32 @@
+Name:       gbp-test3
+Summary:    Test package 3 for git-buildpackage
+Version:    1.0
+Release:    0
+Group:      Development/Libraries
+License:    GPLv2
+Source:     %{name}-%{version}.tar.gz
+# Gbp-Ignore-Patches: 10
+Patch:      my.patch
+Patch10:    my2.patch
+Patch20:    my3.patch
+
+%description
+Another test package for git-buildpackage.
+
+
+%prep
+%autosetup -n %{name}-%{version}
+
+
+%build
+make
+
+
+%install
+mkdir -p %{buildroot}/%{_datadir}/%{name}
+
+
+%files
+%defattr(-,root,root,-)
+%dir %{_datadir}/%{name}
+%{_datadir}/%{name}


### PR DESCRIPTION
Try to do "the right thing" when %autosetup macro is used in the spec
file. That is, do not examine/manage %patch macros at all, but, assume
that patches are handled by %autosetup which was introduced in RPM
v4.11.

Signed-off-by: Markus Lehtonen <markus.lehtonen@linux.intel.com>