### PR TITLE
pq-rpm: implement --drop option

### DIFF
--- a/docs/manpages/gbp-pq-rpm.xml
+++ b/docs/manpages/gbp-pq-rpm.xml
@@ -25,6 +25,7 @@
       <arg><option>--upstream-tag=</option><replaceable>TAG-FORMAT</replaceable></arg>
       <arg><option>--abbrev=</option><replaceable>num</replaceable></arg>
       <arg><option>--force</option></arg>
+      <arg><option>--[no-]drop</option></arg>
       <arg><option>--[no-]patch-numbers</option></arg>
       <group choice="plain">
         <arg><option>drop</option></arg>
@@ -176,6 +177,15 @@
           <para>
           Import even if the development (patch-queue) branch already exists.
           Only valid for the import action.
+          </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term><option>--[no-]drop</option></term>
+        <listitem>
+          <para>
+          Whether to drop (delete) the patch queue branch after a succesful
+          export.
           </para>
         </listitem>
       </varlistentry>

--- a/gbp/scripts/pq_rpm.py
+++ b/gbp/scripts/pq_rpm.py
@@ -204,6 +204,7 @@ def export_patches(repo, options):
         repo.set_branch(base)
         pq_branch = current
     else:
+        base = current
         pq_branch = pq_branch_name(current)
     spec = parse_spec(options, repo)
     upstream_commit = find_upstream_commit(repo, spec, options.upstream_tag)
@@ -212,6 +213,9 @@ def export_patches(repo, options):
     update_patch_series(repo, spec, upstream_commit, export_treeish, options)
 
     GitCommand('status')(['--', spec.specdir])
+
+    if options.drop:
+        drop_pq(repo, base)
 
 
 def safe_patches(queue):
@@ -390,6 +394,7 @@ def build_parser(name):
     parser.add_option("--force", dest="force", action="store_true",
                       default=False,
                       help="In case of import even import if the branch already exists")
+    parser.add_boolean_config_file_option("drop", dest='drop')
     parser.add_config_file_option(option_name="color", dest="color",
                                   type='tristate')
     parser.add_config_file_option(option_name="color-scheme",

--- a/tests/component/rpm/test_pq_rpm.py
+++ b/tests/component/rpm/test_pq_rpm.py
@@ -113,9 +113,11 @@ class TestPqRpm(RpmRepoTestBase):
         self._check_repo_state(repo, 'patch-queue/master-orphan', branches,
                                files)
 
-        # Test export
-        eq_(mock_pq(['export', '--upstream-tag', 'upstream/%(version)s',
-                     '--spec-file', 'packaging/gbp-test2.spec']), 0)
+        # Test export with --drop
+        branches.remove('patch-queue/master-orphan')
+        eq_(mock_pq(['export', '--drop', '--upstream-tag',
+                     'upstream/%(version)s', '--spec-file',
+                     'packaging/gbp-test2.spec']), 0)
         self._check_repo_state(repo, 'master-orphan', branches, clean=False)
         eq_(repo.status()[' M'], [b'packaging/gbp-test2.spec'])
         self._has_patches('packaging/gbp-test2.spec', patches)


### PR DESCRIPTION
Makes it possible to automatically drop the pq-branch after a successful
export. Counterpart for the --drop option of (deb) gbp-pq.

Signed-off-by: Markus Lehtonen <markus.lehtonen@linux.intel.com>