### PR TITLE
tests: enable unittests without devscripts

### DIFF
--- a/tests/11_test_dch_main.py
+++ b/tests/11_test_dch_main.py
@@ -3,12 +3,11 @@
 """Test L{gbp.scripts.dch} main"""
 
 from . import context
-from .testutils import (DebianGitTestRepo, OsReleaseFile,
+from .testutils import (DebianGitTestRepo, OsReleaseFile, skip_without_cmd,
                         get_dch_default_urgency, capture_stderr)
 
 from gbp.scripts import dch
 
-import unittest
 import os
 import re
 
@@ -46,7 +45,7 @@ cl_debian = """test-package (0.9-1) unstable; urgency=%s
 """ % default_urgency
 
 
-@unittest.skipIf(not os.path.exists('/usr/bin/debchange'), "Dch not found")
+@skip_without_cmd('debchange')
 class TestScriptDch(DebianGitTestRepo):
     """Test git-dch"""
 

--- a/tests/12_test_deb.py
+++ b/tests/12_test_deb.py
@@ -136,7 +136,7 @@ Files:
         self.assertEquals(dsc.sigs, [])
 
 
-@unittest.skipIf(not os.path.exists('/usr/bin/dpkg'), 'Dpkg not found')
+@testutils.skip_without_cmd('dpkg')
 class TestDpkgCompareVersions(unittest.TestCase):
     """Test L{gbp.deb.DpkgCompareVersions}"""
 
@@ -160,7 +160,7 @@ class TestDpkgCompareVersions(unittest.TestCase):
             self.cmp('_', '_ _')
 
 
-@unittest.skipIf(not os.path.exists('/usr/bin/dpkg'), 'Dpkg not found')
+@testutils.skip_without_cmd('dpkg')
 class TestDeb(unittest.TestCase):
     """Test L{gbp.deb.__init__} """
 

--- a/tests/13_test_gbp_pq.py
+++ b/tests/13_test_gbp_pq.py
@@ -77,7 +77,7 @@ class TestApplyAndCommit(testutils.DebianGitTestRepo):
         info = self.repo.get_commit_info('HEAD')
         self.assertIn('Gbp-Pq: Name foobar', info['body'])
 
-    @unittest.skipIf(not os.path.exists('/usr/bin/dpkg'), 'Dpkg not found')
+    @testutils.skip_without_cmd('dpkg')
     def test_debian_missing_author(self):
         """
         Check if we parse the author from debian control if it's missing in the patch.

--- a/tests/29_test_gbp_clone.py
+++ b/tests/29_test_gbp_clone.py
@@ -1,9 +1,10 @@
 # vim: set fileencoding=utf-8 :
 from gbp.scripts.clone import vcs_git_url
 
-import os
 import unittest
 from mock import patch
+
+from . testutils import skip_without_cmd
 
 
 class TestGbpClone(unittest.TestCase):
@@ -26,7 +27,7 @@ Vcs-Git: git://honk.sigxcpu.org/git/git-buildpackage.git
 
 """
 
-    @unittest.skipIf(not os.path.exists('/usr/bin/dpkg'), 'Dpkg not found')
+    @skip_without_cmd('dpkg')
     @patch('gbp.scripts.clone.apt_showsrc', return_value=show_src)
     def test_vcs_git_url(self, patch):
         self.assertEqual(vcs_git_url('git-buildpackage'),

--- a/tests/30_test_deb_changelog.py
+++ b/tests/30_test_deb_changelog.py
@@ -8,6 +8,7 @@ also make up the API documentation.
 """
 
 from . import context  # noqa: 401
+from . testutils import skip_without_cmd
 import os
 import unittest
 
@@ -29,6 +30,7 @@ class TestQuoting(unittest.TestCase):
         self.assertEquals(cl.email, 'agx@sigxcpu.org')
 
 
+@skip_without_cmd('debchange')
 class Test(unittest.TestCase):
     def setUp(self):
         self.tmpdir = context.new_tmpdir(__name__)

--- a/tests/component/deb/test_buildpackage.py
+++ b/tests/component/deb/test_buildpackage.py
@@ -27,6 +27,7 @@ from tests.component import (ComponentTestBase,
 from tests.component.deb import DEB_TEST_DATA_DIR
 from tests.component.deb.fixtures import (RepoFixtures,
                                           DEFAULT_OVERLAY)
+from tests.testutils import skip_without_cmd
 
 from nose.tools import ok_, eq_, assert_false, assert_true
 
@@ -289,6 +290,7 @@ class TestBuildpackage(ComponentTestBase):
         repo.checkout("master")
         eq_(repo.rev_parse('master~^{}'), repo.rev_parse('debian/2.8-1^{}'))
 
+    @skip_without_cmd('debchange')
     @RepoFixtures.quilt30()
     def test_broken_upstream_version(self, repo):
         cl = ChangeLog(filename='debian/changelog')

--- a/tests/component/deb/test_dch.py
+++ b/tests/component/deb/test_dch.py
@@ -21,6 +21,7 @@ import os
 from tests.component import ComponentTestBase
 from tests.component.deb import DEB_TEST_DATA_DIR
 from tests.component.deb.fixtures import RepoFixtures
+from tests.testutils import skip_without_cmd
 
 import gbp.scripts.dch
 from gbp.scripts.dch import main as dch
@@ -35,6 +36,7 @@ def _dsc_file(pkg, version, dir='dsc-3.0'):
 DEFAULT_DSC = _dsc_file('hello-debhelper', '2.6-2')
 
 
+@skip_without_cmd('debchange')
 class TestDch(ComponentTestBase):
     """Test importing of new upstream versions"""
     pkg = "hello-debhelper"

--- a/tests/component/deb/test_push.py
+++ b/tests/component/deb/test_push.py
@@ -22,6 +22,7 @@ import subprocess
 from tests.component import ComponentTestBase
 
 from tests.component.deb.fixtures import RepoFixtures
+from tests.testutils import skip_without_cmd
 
 from gbp.git import GitRepository
 from gbp.scripts.push import main as push
@@ -91,6 +92,7 @@ class TestPush(ComponentTestBase):
         self.assertEquals(push(['argv0']), 1)
         self._check_log(-2, ".*You are not on branch 'master' but on 'foo'")
 
+    @skip_without_cmd('debchange')
     @RepoFixtures.quilt30()
     def test_dont_push_unreleased(self, repo):
         repo.add_remote_repo('origin', self.target.path)

--- a/tests/doctests/test_Changelog.py
+++ b/tests/doctests/test_Changelog.py
@@ -4,7 +4,8 @@
 Test L{gbp.deb.changelog.ChangeLog}
 """
 from .. import context  # noqa: 401
-import os
+from .. testutils import have_cmd
+
 import nose
 
 cl_debian = """git-buildpackage (0.5.32) unstable; urgency=low
@@ -48,7 +49,7 @@ cl_epoch = """xserver-xorg-video-nv (1:1.2.0-3) unstable; urgency=low
 
 def setup():
     """Setup test module"""
-    if not os.path.exists('/usr/bin/debchange'):
+    if not have_cmd('debchange'):
         raise nose.SkipTest('debchange tool not present')
 
 

--- a/tests/testutils/__init__.py
+++ b/tests/testutils/__init__.py
@@ -7,6 +7,7 @@ import shutil
 import subprocess
 import tarfile
 import tempfile
+import unittest
 import zipfile
 
 import gbp.log
@@ -22,7 +23,7 @@ __all__ = ['GbpLogTester', 'DebianGitTestRepo', 'OsReleaseFile',
            'MockedChangeLog', 'get_dch_default_urgency',
            'capture_stderr', 'capture_stdout',
            'ls_dir', 'ls_tar', 'ls_zip',
-           'patch_popen']
+           'patch_popen', 'have_cmd', 'skip_without_cmd']
 
 
 class OsReleaseFile(object):
@@ -127,3 +128,16 @@ def ls_zip(archive, directories=True):
         return ls_dir(tmpdir, directories)
     finally:
         shutil.rmtree(tmpdir)
+
+
+def have_cmd(cmd):
+    """Check if a command is available"""
+    return True if shutil.which(cmd) else False
+
+
+def skip_without_cmd(cmd):
+    """Skip if a command is not available"""
+    if have_cmd(cmd):
+        return lambda func: func
+    else:
+        return unittest.skip("Command '%s' not found" % cmd)


### PR DESCRIPTION
Makes it easier to run full unit tests on rpm based systems