### PR TITLE
docs: update references from <http://dep.debian.net> to <https://dep-team.pages.debian.net>

### DIFF
--- a/docs/chapters/patches.xml
+++ b/docs/chapters/patches.xml
@@ -54,7 +54,7 @@
 
   <para>
     Also, beware that &gbp-pq; currently has incomplete support for
-    <ulink url="http://dep.debian.net/deps/dep3/">DEP3</ulink> headers.
+    <ulink url="https://dep-team.pages.debian.net/deps/dep3/">DEP3</ulink> headers.
     Initially, parsing with <command>git-mailinfo(1)</command> is attempted,
     which supports only the <computeroutput>From</computeroutput> and
     <computeroutput>Subject</computeroutput> fields. If neither of these are

--- a/docs/common.ent
+++ b/docs/common.ent
@@ -74,7 +74,7 @@
 
   <!ENTITY changelog " <filename>debian/changelog</filename>">
 
-  <!ENTITY dep14       "<ulink url='http://dep.debian.net/deps/dep14/'><citetitle>DEP-14</citetitle></ulink>">
+  <!ENTITY dep14       "<ulink url='https://dep-team.pages.debian.net/deps/dep14/'><citetitle>DEP-14</citetitle></ulink>">
   <!ENTITY manual      "<ulink url='https://honk.sigxcpu.org/piki/projects/git-buildpackage'>here</ulink>">
   <!ENTITY pyformat    "<ulink url='https://docs.python.org/2/library/stdtypes.html#string-formatting'><citetitle>Python format string</citetitle></ulink>">
  


### PR DESCRIPTION
I don't know for sure if `dep.debian.net` will come back to life, but I don't think so.

Lintian made the move a few days ago: https://salsa.debian.org/lintian/lintian/commit/98cd9cf25