### PR TITLE
gbp.git: fix doctest

### DIFF
--- a/gbp/git/__init__.py
+++ b/gbp/git/__init__.py
@@ -38,10 +38,10 @@ def rfc822_date_to_git(rfc822_date, fuzzy=False):
     '1206000777 -0700'
     >>> rfc822_date_to_git('Sat, 5 Apr 2008 17:01:32 +0200')
     '1207407692 +0200'
-    >>> rfc822_date_to_git('So, 26 Feb 1998 8:50:00 +0100')
+    >>> rfc822_date_to_git('So, 26 Feb 1998 8:50:00 +0100') # doctest: +ELLIPSIS
     Traceback (most recent call last):
     ...
-    ValueError: Unknown string format
+    ValueError:...
     >>> rfc822_date_to_git('So, 26 Feb 1998 8:50:00 +0100', fuzzy=True)
     '888479400 +0100'
     """


### PR DESCRIPTION
Python traceback format seems to have changed slightly between v3.6 and
v3.7.

Signed-off-by: Markus Lehtonen <markus.lehtonen@linux.intel.com>