### PR TITLE
tests: small fix for import-orig-rpm component test

### DIFF
--- a/tests/component/rpm/test_import_orig_rpm.py
+++ b/tests/component/rpm/test_import_orig_rpm.py
@@ -222,6 +222,10 @@ class TestImportOrig(ImportOrigTestBase):
     def test_misc_options(self):
         """Test various options of git-import-orig-rpm"""
         repo = ComponentTestGitRepository.create('.')
+        # Force --no-ff for merges because default behavior is slightly
+        # different in newer git versions (> 2.16)
+        repo.set_config("branch.pack.mergeoptions", "--no-ff")
+
         # Import one orig with default options to get upstream and
         # packaging branch
         orig = os.path.join(DATA_DIR, 'gbp-test-1.0.tar.bz2')


### PR DESCRIPTION
Merge behaviour in newer git versions (> v2.16) is slightly different
which broke one test.

Signed-off-by: Markus Lehtonen <markus.lehtonen@linux.intel.com>