### PR TITLE
setup.py: Fix gbp problem when installed with pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,30 +17,8 @@
 #    <http://www.gnu.org/licenses/>
 # END OF COPYRIGHT #
 
-import subprocess
 from setuptools import setup, find_packages
 import os
-
-
-def fetch_version():
-    """Get version from debian changelog and write it to gbp/version.py"""
-    version = "0.0"
-
-    try:
-        popen = subprocess.Popen('dpkg-parsechangelog', stdout=subprocess.PIPE)
-        out, ret = popen.communicate()
-        for line in out.decode('utf-8').split('\n'):
-            if line.startswith('Version:'):
-                version = line.split(' ')[1].strip()
-                break
-    except OSError:
-        pass  # Failing is fine, we just can't print the version then
-
-    with open('gbp/version.py', 'w') as f:
-        f.write('"The current gbp version number"\n')
-        f.write('gbp_version = "%s"\n' % version)
-
-    return version
 
 
 def readme():
@@ -56,7 +34,7 @@ def setup_requires():
 
 
 setup(name="gbp",
-      version=fetch_version(),
+      version='0.9.10',
       author=u'Guido Günther',
       author_email='agx@sigxcpu.org',
       url='https://honk.sigxcpu.org/piki/projects/git-buildpackage/',


### PR DESCRIPTION
when installed with "pip install gbp" it will be installed as version "0.0"
because the released version doesn't have a debian/changelog file, so it will
be installed with a warning:
balabit-bbos-tools 1.0.0 has requirement gbp==0.9.8, but you'll have gbp 0.0 which is incompatible.

and will cause an Exception when using gbp from a setuptools entrypoint script:
```Traceback (most recent call last):
  File "/home/walkman/stew/projects/platform/source/balabit-os-tools/.venv/lib/python3.6/site-packages/pkg_resources/__init__.py", line 574, in _build_master
    ws.require(__requires__)
  File "/home/walkman/stew/projects/platform/source/balabit-os-tools/.venv/lib/python3.6/site-packages/pkg_resources/__init__.py", line 892, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/home/walkman/stew/projects/platform/source/balabit-os-tools/.venv/lib/python3.6/site-packages/pkg_resources/__init__.py", line 783, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (gbp 0.0 (/home/walkman/stew/projects/platform/source/balabit-os-tools/.venv/lib/python3.6/site-packages), Requirement.parse('gbp==0.9.8'), {'requiresgbp'})
```

This is because pkg_resources checks every dependency version and if it doesn't
match with the egg-info, it raises this Exception.

The fetch_version command is "too expensive" anyway, and it requires an external
dependency during pip install time, which is not expectabel from users. It is
not really a big deal to manually change the version for every release in
setup.py beside debian/changelog and it makes the pypi package properly
installable.