### PR TITLE
buildpackage: support version substitution for --git-tarball-dir

### DIFF
--- a/docs/manpages/gbp-buildpackage.xml
+++ b/docs/manpages/gbp-buildpackage.xml
@@ -222,6 +222,8 @@
               Search for upstream tarballs in <replaceable>DIRECTORY</replaceable>
               instead of generating them. If a tarball is not found here it
               will be generated nevertheless.
+              <replaceable>DIRECTORY</replaceable> can contain a version format
+              substitution pattern, eg: <replaceable>foo-%(version)s</replaceable>.
             </para>
           </listitem>
 	</varlistentry>

--- a/docs/manpages/gbp-export-orig.xml
+++ b/docs/manpages/gbp-export-orig.xml
@@ -146,6 +146,8 @@
           <para>
           Search for original tarballs in <replaceable>DIRECTORY</replaceable>
           instead of generating them.
+          <replaceable>DIRECTORY</replaceable> can contain a version format
+          substitution pattern, eg: <replaceable>foo-%(version)s</replaceable>.
           </para>
         </listitem>
       </varlistentry>

--- a/gbp/deb/git.py
+++ b/gbp/deb/git.py
@@ -22,9 +22,9 @@ import re
 from gbp.command_wrappers import CommandExecFailed
 from gbp.git import GitRepositoryError
 from gbp.deb.pristinetar import DebianPristineTar
-from gbp.format import format_str
 from gbp.paths import to_bin
 from gbp.pkg.git import PkgGitRepository
+from gbp.pkg.pkgpolicy import PkgPolicy
 
 import gbp.log
 
@@ -169,9 +169,7 @@ class DebianGitRepository(PkgGitRepository):
         >>> DebianGitRepository.version_to_tag(r'%(version%-%\\%)s', "0-1.2.3")
         '0%1.2.3'
         """
-        f, v = cls._mangle_version(format, version)
-        return format_str(f, dict(version=cls._sanitize_version(v),
-                                  hversion=cls._sanitize_version(v).replace('.', '-')))
+        return PkgPolicy.version_subst(format, version, cls._sanitize_version)
 
     @classmethod
     def _mangle_version(cls, format, version):

--- a/gbp/scripts/buildpackage.py
+++ b/gbp/scripts/buildpackage.py
@@ -45,6 +45,7 @@ from gbp.scripts.common.hook import Hook
 
 from gbp.scripts.export_orig import prepare_upstream_tarballs, guess_comp_type
 from gbp.scripts.tag import perform_tagging
+from gbp.pkg.pkgpolicy import PkgPolicy
 
 
 # Functions to handle export-dir
@@ -499,7 +500,9 @@ def main(argv):
 
         if not options.tag_only:
             output_dir = prepare_output_dir(options.export_dir)
-            tarball_dir = options.tarball_dir or output_dir
+            tarball_dir = output_dir
+            if options.tarball_dir and source.upstream_version is not None:
+                tarball_dir = PkgPolicy.version_subst(options.tarball_dir, source.upstream_version)
             tmp_dir = os.path.join(output_dir, "%s-tmp" % source.sourcepkg)
             build_env, hook_env = setup_pbuilder(options, repo, source.is_native())
             major = (source.debian_version if source.is_native()

--- a/gbp/scripts/export_orig.py
+++ b/gbp/scripts/export_orig.py
@@ -29,6 +29,7 @@ import gbp.log
 import gbp.notifications
 from gbp.scripts.common import ExitCodes
 from gbp.pkg import Compressor, Archive
+from gbp.pkg.pkgpolicy import PkgPolicy
 
 
 def prepare_upstream_tarballs(repo, source, options, tarball_dir, output_dir):
@@ -334,6 +335,10 @@ def main(argv):
             source.is_native()
         except Exception as e:
             raise GbpError("Can't determine package type: %s" % e)
+
+        if options.tarball_dir and source.upstream_version is not None:
+            options.tarball_dir = PkgPolicy.version_subst(options.tarball_dir,
+                                                          source.upstream_version)
 
         output_dir = options.tarball_dir or os.path.join(repo.path, '..')
 

--- a/tests/component/deb/test_buildpackage.py
+++ b/tests/component/deb/test_buildpackage.py
@@ -312,3 +312,24 @@ class TestBuildpackage(ComponentTestBase):
                                        '--git-preexport=printenv > %s' % preexport_out])
         ok_(os.path.exists(preexport_out))
         self.check_hook_vars('../preexport', ["GBP_BUILD_DIR", "GBP_GIT_DIR"])
+
+    @RepoFixtures.overlay()
+    def test_export_dir_version_replacement(self, repo):
+        """Test that building in overlay mode with export dir with versioned name works"""
+        tarball_dir = os.path.join(DEB_TEST_DATA_DIR, 'foo-%(version)s')
+        self._test_buildpackage(repo, ['--git-overlay',
+                                       '--git-compression=auto',
+                                       '--git-tarball-dir=%s' % tarball_dir,
+                                       '--git-no-purge',
+                                       '--git-component=foo',
+                                       '--git-export-dir=../foo'])
+        # Check if main tarball got unpacked
+        ok_(os.path.exists('../foo/hello-debhelper-2.8/configure'))
+        # Check if debian dir is there
+        ok_(os.path.exists('../foo/hello-debhelper-2.8/debian/changelog'))
+        # Check if additional tarball got unpacked
+        ok_(os.path.exists('../foo/hello-debhelper-2.8/foo/test1'))
+        # Check if upstream tarballs is in export_dir
+        eq_(sorted(glob.glob('../foo/*')), ['../foo/hello-debhelper-2.8',
+                                            '../foo/hello-debhelper_2.8.orig-foo.tar.gz',
+                                            '../foo/hello-debhelper_2.8.orig.tar.gz'])


### PR DESCRIPTION
Closes: #909266

Signed-off-by: Luca Boccassi <bluca@debian.org>


As requested on the ticket, I created a new method in PkgPolicy.
The test needs: https://github.com/agx/git-buildpackage-deb-testdata/pull/1