### PR TITLE
Bug #915629: Allow --ignore-branch for 'gbp pq'

### DIFF
--- a/gbp/scripts/pq.py
+++ b/gbp/scripts/pq.py
@@ -487,7 +487,8 @@ def main(argv):
         except GitRepositoryError:
             # Not being on any branch is OK with --ignore-branch
             if options.ignore_branch:
-                current = repo.get_commits(num=1,
+                current = repo.get_commits(
+                    num=1,
                     options=["--pretty=format:%h"]  # Force abbreviated commit hash
                 )[0]
             else:


### PR DESCRIPTION
* 4c0f956 adds support for the `import` command. Is this a good way to do it?

* 22fe91b is a cosmetic change just to generate shorter `patch-queue/` branch names. With this, patch queue branches will be named such as `patch-queue/03e0b41`. Without this, pq branches would be named like `patch-queue/03e0b4134690062fb7a358592f85df8c7ff31bbd`. This is just a cosmetic commit, not very important given that patch-queue branches tend to be short lived. But it's added here just in case it's seen as a good idea.