### PR TITLE
Add --git-ignore-pattern option.

### DIFF
--- a/gbp/git/repository.py
+++ b/gbp/git/repository.py
@@ -829,7 +829,7 @@ class GitRepository(object):
             args.add(commit, '--')
             self._git_command("reset", args.args)
 
-    def _status(self, porcelain, ignore_untracked, paths):
+    def _status(self, porcelain, ignore_untracked, ignore_pattern, paths):
         args = GitArgs()
         args.add_true(ignore_untracked, '-uno')
         args.add_true(porcelain, '--porcelain')
@@ -842,11 +842,15 @@ class GitRepository(object):
         out, ret = self._git_getoutput('status',
                                        args.args + paths,
                                        extra_env={'LC_ALL': 'C'})
+        if ignore_pattern:
+            regex = re.compile(ignore_pattern.encode('utf-8'))
+            out = [i for i in out if not regex.search(i)]
+
         if ret:
             raise GitRepositoryError("Can't get repository status")
         return out
 
-    def is_clean(self, ignore_untracked=False, paths=None):
+    def is_clean(self, ignore_untracked=False, paths=None, ignore_pattern=None):
         """
         Does the repository contain any uncommitted modifications?
 
@@ -859,16 +863,19 @@ class GitRepository(object):
             and Git's status message
         @rtype: C{tuple}
         """
+
         if self.bare:
             return (True, '')
 
         out = self._status(porcelain=True,
                            ignore_untracked=ignore_untracked,
+                           ignore_pattern=ignore_pattern,
                            paths=paths)
         if out:
             # Get a more helpful error message.
             out = self._status(porcelain=False,
                                ignore_untracked=ignore_untracked,
+                               ignore_pattern=ignore_pattern,
                                paths=paths)
             return (False, "".join([e.decode() for e in out]))
         else:

--- a/gbp/scripts/buildpackage.py
+++ b/gbp/scripts/buildpackage.py
@@ -179,11 +179,11 @@ def clean_working_tree(options, repo):
     """
     Command(options.cleaner, shell=True)()
     if not options.ignore_new:
-        (ret, out) = repo.is_clean()
+        (ret, out) = repo.is_clean(ignore_pattern=options.ignore_pattern)
         if not ret:
             gbp.log.err("You have uncommitted changes in your source tree:")
             gbp.log.err(out)
-            raise GbpError("Use --git-ignore-new to ignore.")
+            raise GbpError("Use --git-ignore-new or --git-ignore-pattern to ignore.")
 
 
 def check_tag(options, repo, source):
@@ -361,6 +361,8 @@ def build_parser(name, prefix=None):
         parser.add_option_group(group)
 
     parser.add_boolean_config_file_option(option_name="ignore-new", dest="ignore_new")
+    parser.add_option("--git-ignore-pattern", dest="ignore_pattern", default=None,
+                      help="regex to ignore new or dirty files")
     parser.add_option("--git-verbose", action="store_true", dest="verbose", default=False,
                       help="verbose command execution")
     parser.add_config_file_option(option_name="color", dest="color", type='tristate')


### PR DESCRIPTION
It can be used to ignore certain paths or files from the repo.is_clean check.
It's an alternative to the --git-ignore-new parameter, when you only
need to skip a certain path.

This comes from the need to store ccache inside the working directory on Gitlab pipelines. 

Issue: https://salsa.debian.org/salsa-ci-team/pipeline/issues/27
Workaround: https://salsa.debian.org/salsa-ci-team/pipeline/merge_requests/63/diffs#d02988742a4e38af0efe3a7f4c522afc7e77728a_34_41