### PR TITLE
Pass an array of one string instead of a string to GitArgs

### DIFF
--- a/gbp/git/args.py
+++ b/gbp/git/args.py
@@ -56,7 +56,7 @@ class GitArgs(object):
         Add arguments to argument list
         """
         for arg in args:
-            if isinstance(arg, str):
+            if isinstance(arg, basestring):
                 self._args.append(arg)
             elif isinstance(arg, collections.Iterable):
                 for i in iter(arg):


### PR DESCRIPTION
As the code currently is, gbp ends up calling e.g.:

```
execve(["git", "log", "--pretty=format:%H", "1", "2", "3", ...])
```

Which fails with "Failed to get revision 1", of course.

After the fix, it properly does:

```
execve(["git", "log", "--pretty=format:%H", "123...HEAD"])
```