### PR TITLE
add option to export tarballs with upstream signature

### DIFF
--- a/docs/manpages/gbp-buildpackage.xml
+++ b/docs/manpages/gbp-buildpackage.xml
@@ -50,6 +50,7 @@
       <arg><option>--git-upstream-tag=</option><replaceable>tag-format</replaceable></arg>
       <arg><option>--git-force-create</option></arg>
       <arg><option>--git-no-create-orig</option></arg>
+      <arg><option>--git-upstream-signatures=</option>[auto|on|off]</arg>
       <arg><option>--git-upstream-tree=</option><replaceable>[BRANCH|SLOPPY|TAG|TREEISH]</replaceable></arg>
       <arg><option>--git-tarball-dir=</option><replaceable>DIRECTORY</replaceable></arg>
       <arg><option>--git-compression=</option><replaceable>TYPE</replaceable></arg>
@@ -273,6 +274,15 @@
             <para>
               Don't try to create any upstream tarballs or to create
               symlinks to existing tarballs in <option>tarball-dir</option>.
+            </para>
+          </listitem>
+	</varlistentry>
+	<varlistentry>
+          <term><option>--git-upstream-signatures=</option>[auto|on|off]
+          </term>
+          <listitem>
+            <para>
+              Whether to export the upstream tarball with signatures.
             </para>
           </listitem>
 	</varlistentry>

--- a/docs/manpages/gbp-export-orig.xml
+++ b/docs/manpages/gbp-export-orig.xml
@@ -31,6 +31,7 @@
       <arg><option>--compression-level=</option><replaceable>LEVEL</replaceable></arg>
       <arg rep='repeat'><option>--component=</option><replaceable>component</replaceable></arg>
       <arg><option>--[no-]pristine-tar</option></arg>
+      <arg><option>--upstream-signatures=</option>[auto|on|off]</arg>
     </cmdsynopsis>
   </refsynopsisdiv>
   <refsect1>
@@ -206,6 +207,15 @@
         </listitem>
       </varlistentry>
     </variablelist>
+    <varlistentry>
+        <term><option>--upstream-signatures=</option>[auto|on|off]
+        </term>
+        <listitem>
+          <para>
+          Whether to export with upstream signatures.
+          </para>
+        </listitem>
+      </varlistentry>
   </refsect1>
   <refsect1>
     <title>EXAMPLES</title>

--- a/gbp/scripts/buildpackage.py
+++ b/gbp/scripts/buildpackage.py
@@ -395,6 +395,8 @@ def build_parser(name, prefix=None):
                                       help="Compression type, default is '%(compression)s'")
     orig_group.add_config_file_option(option_name="compression-level", dest="comp_level",
                                       help="Compression level, default is '%(compression-level)s'")
+    orig_group.add_config_file_option(option_name="upstream-signatures", dest="upstream_signatures",
+                                      help="use upstream signatures, default is auto", type='tristate')
     orig_group.add_config_file_option("component", action="append", metavar='COMPONENT',
                                       dest="components")
     branch_group.add_config_file_option(option_name="upstream-branch", dest="upstream_branch")

--- a/gbp/scripts/export_orig.py
+++ b/gbp/scripts/export_orig.py
@@ -113,7 +113,8 @@ def pristine_tar_build_origs(repo, source, output_dir, options):
                                                   source.upstream_tarball_name(comp.type))))
         repo.create_upstream_tarball_via_pristine_tar(source,
                                                       output_dir,
-                                                      comp)
+                                                      comp,
+                                                      options.upstream_signatures)
         for component in options.components:
             gbp.log.info("Creating %s" %
                          os.path.abspath(os.path.join(output_dir,
@@ -121,6 +122,7 @@ def pristine_tar_build_origs(repo, source, output_dir, options):
             repo.create_upstream_tarball_via_pristine_tar(source,
                                                           output_dir,
                                                           comp,
+                                                          options.upstream_signatures,
                                                           component=component)
         return True
     except GitRepositoryError:
@@ -303,6 +305,8 @@ def build_parser(name):
                                       help="Compression type, default is '%(compression)s'")
     orig_group.add_config_file_option(option_name="compression-level", dest="comp_level",
                                       help="Compression level, default is '%(compression-level)s'")
+    orig_group.add_config_file_option(option_name="upstream-signatures", dest="upstream_signatures",
+                                      help="use upstream signature, default is auto", type='tristate')
     orig_group.add_config_file_option("component", action="append", metavar='COMPONENT',
                                       dest="components")
     branch_group.add_config_file_option(option_name="upstream-branch", dest="upstream_branch")

--- a/gbp/scripts/push.py
+++ b/gbp/scripts/push.py
@@ -164,7 +164,7 @@ def main(argv):
                 to_push['refs'].append((ref, get_push_src(repo, ref, utag)))
 
             if options.pristine_tar:
-                commit = repo.get_pristine_tar_commit(source)
+                commit, _ = repo.get_pristine_tar_commit(source)
                 if commit:
                     ref = 'refs/heads/pristine-tar'
                     to_push['refs'].append((ref, get_push_src(repo, ref, commit)))

--- a/tests/doctests/test_PristineTar.py
+++ b/tests/doctests/test_PristineTar.py
@@ -134,9 +134,18 @@ def test_pristine_has_commit():
     >>> repo.pristine_tar.has_commit('upstream', '1.0')
     True
     >>> branch = repo.rev_parse('pristine-tar')
-    >>> commit = repo.pristine_tar.get_commit('upstream_1.0.orig.tar.gz')
+    >>> commit, sig = repo.pristine_tar.get_commit('upstream_1.0.orig.tar.gz')
     >>> branch == commit
     True
+    >>> sig
+    True
+    >>> repo.pristine_tar.commit('../upstream_1.0.orig.tar.gz', 'upstream')
+    >>> branch = repo.rev_parse('pristine-tar')
+    >>> commit, sig = repo.pristine_tar.get_commit('upstream_1.0.orig.tar.gz')
+    >>> branch == commit
+    True
+    >>> sig
+    False
     """
 
 


### PR DESCRIPTION
Add option `--upstream-signatures=[on|auto|off]` to export-orig.
Add option `--git-upstream-signatures=[on|auto|off]` to buildpackage.

Closes: 872864