### PR TITLE
import-orig: Allow the post-unpack hook to filter tarball files

### DIFF
--- a/docs/manpages/gbp-import-orig.xml
+++ b/docs/manpages/gbp-import-orig.xml
@@ -346,6 +346,12 @@
 		The temporary directory the tarballs are unapcked into.
 	      </para></listitem>
 	    </varlistentry>
+        <varlistentry>
+	      <term><envar>GBP_SOURCES_DIR</envar></term>
+	      <listitem><para>
+		The temporary directory where the unpacked sources are.
+	      </para></listitem>
+	    </varlistentry>
 	    <varlistentry>
 	      <term><envar>GBP_GIT_DIR</envar></term>
 	      <listitem><para>

--- a/gbp/scripts/common/import_orig.py
+++ b/gbp/scripts/common/import_orig.py
@@ -40,19 +40,25 @@ def orig_needs_repack(upstream_source, options):
     Determine if the upstream sources needs to be repacked
 
     We repack if
-     1. we want to filter out files and use pristine tar since we want
-        to make a filtered tarball available to pristine-tar
+     1. we want to filter out files via filters or post-unpack script and use
+        pristine tar since we want to make a filtered tarball available to
+        pristine-tar
      2. we don't have a suitable upstream tarball (e.g. zip archive or unpacked dir)
         and want to use filters
      3. we don't have a suitable upstream tarball (e.g. zip archive or unpacked dir)
         and want to use pristine-tar
+     4. we don't have a suitable upstream tarball (e.g. zip archive or unpacked dir)
+        and want to use a post-unpack script
     """
-    if ((options.pristine_tar and options.filter_pristine_tar and len(options.filters) > 0)):
+    if ((options.pristine_tar and options.filter_pristine_tar and
+       (options.filters or options.postunpack))):
         return True
     elif not upstream_source.is_orig():
         if len(options.filters):
             return True
         elif options.pristine_tar:
+            return True
+        elif options.postunpack:
             return True
     return False
 

--- a/gbp/scripts/import_orig.py
+++ b/gbp/scripts/import_orig.py
@@ -227,11 +227,12 @@ def postimport_hook(repo, tag, version, options):
              extra_env=env)()
 
 
-def postunpack_hook(repo, tmp_dir, options):
+def postunpack_hook(repo, tmp_dir, sources, options):
     if options.postunpack:
         Hook('Postunpack', options.postunpack,
              extra_env={'GBP_GIT_DIR': repo.git_dir,
-                        'GBP_TMP_DIR': tmp_dir}
+                        'GBP_TMP_DIR': tmp_dir,
+                        'GBP_SOURCES_DIR': sources[0].unpacked}
              )(dir=tmp_dir)
 
 
@@ -474,7 +475,7 @@ def main(argv):
 
         sources, tmpdir = unpack_tarballs(name, sources, version, options)
         try:
-            postunpack_hook(repo, tmpdir, options)
+            postunpack_hook(repo, tmpdir, sources, options)
         except gbpc.CommandExecFailed:
             raise GbpError()  # The hook already printed an error message
 

--- a/tests/component/deb/test_import_orig.py
+++ b/tests/component/deb/test_import_orig.py
@@ -401,3 +401,18 @@ class TestImportOrig(ComponentTestBase):
                                                ("GBP_TAG", "upstream/2.8"),
                                                ("GBP_UPSTREAM_VERSION", "2.8"),
                                                ("GBP_DEBIAN_VERSION", "2.8-1")])
+
+    def test_postunpack_env_vars(self):
+        """
+        Test that the expected environment variables are set during
+        postunpack hook.
+        """
+        repo = ComponentTestGitRepository.create(self.pkg)
+        os.chdir(self.pkg)
+        orig = self._orig('2.8')
+        ok_(import_orig(['arg0',
+                         '--postunpack=printenv > ../postunpack.out',
+                         '--no-interactive', '--pristine-tar', orig]) == 0)
+        self.check_hook_vars('../postunpack', ["GBP_GIT_DIR",
+                                               "GBP_TMP_DIR",
+                                               "GBP_SOURCES_DIR"])


### PR DESCRIPTION
With post-unpack scripts is currently possible to filter out files that are
not needed from the upstream branch, however it is not possible to use it to
filter files that will end up in the orig file, and in some scenarios this
is not easily doable just using a filter list.

So, run the post-unpack hook just after unpacking and before repacking the
tar

Closes #812721
Closes #951534

---

I was wondering if would be the case to add another option to change this behavior (although I only see few cases where it is used in the debian and ubuntu archives), or to repack only if such toggle is set, but I suppose that `filter_pristine_tar` is just enough for this.

An alternative would be to have another hook, but I think it would just over-complicate things.