### PR TITLE
Add info about --git-ignore-branch when not on branch

### DIFF
--- a/gbp/scripts/buildpackage.py
+++ b/gbp/scripts/buildpackage.py
@@ -328,10 +328,11 @@ def check_branch(repo, options):
     branch = None
     try:
         branch = repo.get_branch()
-    except GitRepositoryError:
+    except GitRepositoryError as repo_error:
         # Not being on any branch is o.k. with --git-ignore-branch
         if not options.ignore_branch:
-            raise
+            gbp.log.err(repo_error)
+            raise GitRepositoryError("Use --git-ignore-branch to ignore")
 
     ignore = options.ignore_new or options.ignore_branch
     if branch != options.debian_branch and not ignore:


### PR DESCRIPTION
I checked out a tag to build using `gbp buildpackage`. I soon received the error `Currently not on a branch`. Of course this is normal, but I didn't know to use `--git-ignore-branch` at the time.
https://github.com/agx/git-buildpackage/blob/657b005c5d07f7e53ce8be417961d67f71a1f07e/gbp/scripts/buildpackage.py#L331-L334
Eventually, (after some man page diving, and eventually code diving) I found it, but it was not immediately clear to me the first time.

gbp already helpfully informs you when on a different branch than your configured debian branch.
https://github.com/agx/git-buildpackage/blob/657b005c5d07f7e53ce8be417961d67f71a1f07e/gbp/scripts/buildpackage.py#L337-L340

So, now gbp will also help you when not on a branch at all, by appending `Use --git-ignore-branch to ignore` to the `Currently not on a branch` error.