### PR TITLE
import-dsc: Delete NULs from the list of changes before committing

### DIFF
--- a/gbp/deb/changelog.py
+++ b/gbp/deb/changelog.py
@@ -99,7 +99,7 @@ class ChangeLog(object):
         if cmd.returncode:
             raise ParseChangeLogError("Failed to parse changelog. "
                                       "dpkg-parsechangelog said:\n%s" % stderr.decode().strip())
-        return stdout.decode()
+        return stdout.decode().replace('\0', '')
 
     def _parse(self):
         """Parse a changelog based on the already read contents."""

--- a/tests/30_test_deb_changelog.py
+++ b/tests/30_test_deb_changelog.py
@@ -30,6 +30,21 @@ class TestQuoting(unittest.TestCase):
         self.assertEquals(cl.email, 'agx@sigxcpu.org')
 
 
+class TestEncoding(unittest.TestCase):
+    def test_nul(self):
+        """Test we remove NUL characters from strings when parsing (#981340)"""
+        changes = """git-buildpackage (0.9.2) unstable; urgency=low
+
+  * List of ch\0nges
+
+ -- User N\0me <agx@sigxcpu.org>  Sun, 12 Nov 2017 19:00:00 +0200
+"""
+        cl = ChangeLog(changes)
+        self.assertEquals(cl.author, 'User Nme')
+        self.assertEquals(cl.email, 'agx@sigxcpu.org')
+        self.assertEquals('\0' in cl.get_changes(), False)
+
+
 @skip_without_cmd('debchange')
 class Test(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Commit messages may not contain NUL characters; in practice, Debian changelogs sometimes do, usually as the result of
incorrectly used encoding for non-ASCII personal names. An example is this dash version, the NUL is in the entry for ash (0.3.8-14):

https://snapshot.debian.org/archive/debian-archive/20120328T092752Z/debian/pool/main/d/dash/dash_0.5.4-12.dsc

This change is to delete all NULs from the list of changes before committing to the packaging branch.

Without this fix, gbp import-dsc fails to import a dsc when the changelog has NUL characters embedded into it:

    gbp:error: Failed to commit tree: error: a NUL byte in commit log message not allowed.
    e: Failed to commit tree: error: a NUL byte in commit log message not allowed.

This merge request closes the Debian bug [#981340](https://bugs.debian.org/981340).

If the test data were on GitHub or Salsa, I’d have submitted a change request there too and [the patch for the tests](https://github.com/agx/git-buildpackage/files/5927537/0001-test_import_dsc-Test-importing-a-package-with-NULs.patch.txt). This new tests assumes the following:
```
	new file:   dsc-3.0/dash_0.5.4-12.diff.gz
	new file:   dsc-3.0/dash_0.5.4-12.dsc
	new file:   dsc-3.0/dash_0.5.4.orig.tar.gz
```