### PR TITLE
setup gitattributes on clone

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -57,18 +57,18 @@ Recommends: pristine-tar (>= 1.41),
 Suggests: python3-notify2, unzip, sudo
 Description: Suite to help with Debian packages in Git repositories
  This package contains the following tools:
-  * gbp buildpackage: build a package out of a git repository, check for local
+  * gbp buildpackage: build a package out of a Git repository, check for local
     modifications and tag appropriately
-  * gbp import-orig: import a new upstream version into the git repository
-  * gbp export-orig: export an upstream tarball from the git repository
-  * gbp import-{dsc,dscs}: import existing Debian source packages into a git
+  * gbp import-orig: import a new upstream version into the Git repository
+  * gbp export-orig: export an upstream tarball from the Git repository
+  * gbp import-{dsc,dscs}: import existing Debian source packages into a Git
     repository
   * gbp dch: generate Debian changelog entries from Git commit messages
   * gbp {pull,clone}: clone and pull from remote repos
   * gbp pq: manage debian/patches easily
   * gbp create-remote-repo: create remote repositories
   * gbp push: push content to remote repositories
-  * gbp tag: tag a Debian package in git
+  * gbp tag: tag a Debian package in Git
   * gbp pristine-tar: create pristine-tar commits
   * gbp setup-gitattributes: set up Git attributes to disable transformations
 
@@ -84,9 +84,9 @@ Recommends: pristine-tar (>= 0.5)
 Suggests: python3-notify, unzip, zipmerge, mock
 Description: Suite to help with RPM packages in Git repositories
  This package contains the following tools:
-  * gbp buildpackage-rpm: build a package out of a git repository, check for
+  * gbp buildpackage-rpm: build a package out of a Git repository, check for
     local modifications and tag appropriately
-  * gbp import-srpm: import existing RPM source packages into a git
+  * gbp import-srpm: import existing RPM source packages into a Git
     repository
   * gbp pq-rpm: manage patches easily
  .

--- a/debian/control
+++ b/debian/control
@@ -70,6 +70,7 @@ Description: Suite to help with Debian packages in Git repositories
   * gbp push: push content to remote repositories
   * gbp tag: tag a Debian package in git
   * gbp pristine-tar: create pristine-tar commits
+  * gbp setup-gitattributes: set up Git attributes to disable transformations
 
 Package: git-buildpackage-rpm
 Architecture: all

--- a/debian/git-buildpackage.install
+++ b/debian/git-buildpackage.install
@@ -30,6 +30,7 @@ usr/lib/python3.?/dist-packages/gbp/scripts/pq.py usr/lib/python3/dist-packages/
 usr/lib/python3.?/dist-packages/gbp/scripts/pristine_tar.py usr/lib/python3/dist-packages/gbp/scripts/
 usr/lib/python3.?/dist-packages/gbp/scripts/pull.py usr/lib/python3/dist-packages/gbp/scripts/
 usr/lib/python3.?/dist-packages/gbp/scripts/push.py usr/lib/python3/dist-packages/gbp/scripts/
+usr/lib/python3.?/dist-packages/gbp/scripts/setup_gitattributes.py usr/lib/python3/dist-packages/gbp/scripts/
 usr/lib/python3.?/dist-packages/gbp/scripts/supercommand.py usr/lib/python3/dist-packages/gbp/scripts/
 usr/lib/python3.?/dist-packages/gbp/scripts/tag.py usr/lib/python3/dist-packages/gbp/scripts/
 usr/lib/python3.?/dist-packages/gbp/tmpfile.py usr/lib/python3/dist-packages/gbp/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -16,6 +16,7 @@ MAN1S = \
         gbp-pristine-tar  \
         gbp-pull          \
         gbp-push          \
+        gbp-setup-gitattributes \
         gbp-tag           \
         gbp-buildpackage-rpm \
         gbp-import-srpm   \

--- a/docs/common.ent
+++ b/docs/common.ent
@@ -35,6 +35,7 @@
   <!ENTITY gbp-pristine-tar	"<command>gbp&nbsp;pristine-tar</command>">
   <!ENTITY gbp-pull		"<command>gbp&nbsp;pull</command>">
   <!ENTITY gbp-push		"<command>gbp&nbsp;push</command>">
+  <!ENTITY gbp-setup-gitattributes "<command>gbp&nbsp;setup-gitattributes</command>">
   <!ENTITY gbp-rpm-ch           "<command>gbp rpm-ch</command>">
   <!ENTITY gbp-tag              "<command>gbp tag</command>">
   <!ENTITY gbp.conf		"<filename>gbp.conf</filename>">

--- a/docs/man.gbp.xml
+++ b/docs/man.gbp.xml
@@ -30,5 +30,6 @@
 &man.gbp.pull;
 &man.gbp.push;
 &man.gbp.rpm.ch;
+&man.gbp.setup.gitattributes;
 &man.gbp.tag;
 </reference>

--- a/docs/manpages/gbp-clone.xml
+++ b/docs/manpages/gbp-clone.xml
@@ -30,6 +30,7 @@
       <arg><option>--reference=</option><replaceable>repository</replaceable></arg>
       <arg><option>--postclone=</option><replaceable>COMMAND</replaceable></arg>
       <arg><option>--[no-]hooks</option></arg>
+      <arg><option>--defuse-gitattributes=</option><replaceable>[auto|on|off]</replaceable></arg>
       <arg><option>--repo-user=</option><option>[GIT|DEBIAN]</option></arg>
       <arg><option>--repo-email=</option><option>[GIT|DEBIAN]</option></arg>
       <arg choice="plain"><replaceable>repository</replaceable></arg>
@@ -123,6 +124,27 @@
 	</listitem>
       </varlistentry>
       <varlistentry>
+	<term><option>--defuse-gitattributes=</option><option>[auto|on|off]</option></term>
+	<listitem>
+          <para>
+            Disable Git attributes that may interfere with building packages. Works
+            by updating <filename>.git/info/attributes</filename> to override attributes
+            in the upstream sources which may cause files to be transformed on checkout.
+            More specifically, a new macro attribute is defined, <symbol>[attr]dgit-defuse-attrs</symbol>,
+            which is then applied to <filename>*</filename> together with <symbol>export-subst</symbol>
+            and <symbol>export-ignore</symbol>. This is done to be compatible with <command>dgit</command>
+            and <command>git-deborig</command> which disable Git attributes this way.
+          </para>
+          <para>
+            If set to <replaceable>auto</replaceable>, first check whether there
+            are any <filename>.gitattributes</filename> files in the upstream source,
+            and act only if there are some. If set to <replaceable>on</replaceable>,
+            unconditionally there are some. If set to <replaceable>off</replaceable>,
+            does nothing.
+          </para>
+	</listitem>
+      </varlistentry>
+      <varlistentry>
 	<term><option>--repo-email=</option><option>[GIT|DEBIAN]</option></term>
         <listitem>
           <para>
@@ -195,7 +217,11 @@
     <para>
       <xref linkend="man.gbp.buildpackage"/>,
       <xref linkend="man.gbp.pull"/>,
-      <xref linkend="man.gbp.conf"/>
+      <xref linkend="man.gbp.conf"/>,
+      <citerefentry>
+        <refentrytitle>gitattributes</refentrytitle>
+        <manvolnum>5</manvolnum>
+      </citerefentry>
     </para>
   </refsect1>
   <refsect1>

--- a/docs/manpages/gbp-clone.xml
+++ b/docs/manpages/gbp-clone.xml
@@ -217,6 +217,7 @@
     <para>
       <xref linkend="man.gbp.buildpackage"/>,
       <xref linkend="man.gbp.pull"/>,
+      <xref linkend="man.gbp.setup.gitattributes"/>,
       <xref linkend="man.gbp.conf"/>,
       <citerefentry>
         <refentrytitle>gitattributes</refentrytitle>

--- a/docs/manpages/gbp-setup-gitattributes.xml
+++ b/docs/manpages/gbp-setup-gitattributes.xml
@@ -13,43 +13,69 @@
   </refmeta>
   <refnamediv>
     <refname>gbp-setup-gitattributes</refname>
-    <refpurpose>Set up &git; attributes to disable transformations</refpurpose>
+    <refpurpose>Set up &git; attributes for packaging</refpurpose>
   </refnamediv>
   <refsynopsisdiv>
     <cmdsynopsis>
       &gbp-setup-gitattributes;
 
       &man.common.options.synopsis;
+      <arg><option>--[no-]dgit-defuse-attrs</option></arg>
+      <arg><option>--all</option></arg>
     </cmdsynopsis>
   </refsynopsisdiv>
   <refsect1>
     <title>DESCRIPTION</title>
     <para>
       &gbp-setup-gitattributes; sets up <filename>.git/info/attributes</filename> in the current
-      repository to disable all transforming attributes for all files. This is done by defining
-      a macro attribute <symbol>[attr]dgit-defuse-attrs</symbol> and applying it to <filename>*</filename>
-      together with <symbol>export-subst</symbol> and <symbol>export-ignore</symbol>.
+      &git; repository to sane defaults most suitable for packaging work. At the moment, this
+      amounts to making sure no transformations happen during checkout, commit or export. More
+      attributes may be added in future, by default all known settings are applied.
     </para>
     <para>
-      This method is compatible with <command>dgit</command> and <command>git-deborig</command>
-      which use this macro attribute. Older versions of <command>dgit</command> use an incomplete
-      preset missing some attributes; if such is found, it is replaced by an updated definition.
-    </para>
-    <para>
-      Disabling those attributes is necessary, since they cause often unwanted conversion of files
-      on checkout (e.g. line endings, encodings, etc). Working with such source tree is confusing,
+      Upstream sources may ship <filename>.gitattributes</filename> files enabling certain
+      transformations to the committed source, usually to make working with files in different
+      encodings more convenient for the upstream authors. For Debian packaging, it is necessary
+      to override these attributes, since they cause often unwanted conversion of files (e.g.
+      line endings, encodings and some others). Working with such source tree is confusing,
       since the working tree differs from the Git history (and sometimes from the source tarball),
       and can lead to errors.
     </para>
     <para>
       By default, &gbp-clone; tries to detect the usage of <filename>.gitattributes</filename> in the
-      upstream source and disable the Git attributes only when necessary.
+      upstream source and disables the Git attributes only when necessary.
     </para>
   </refsect1>
   <refsect1>
     <title>OPTIONS</title>
     <variablelist>
       &man.common.options.description;
+      <varlistentry>
+        <term><option>--[no-]dgit-defuse-attrs</option>
+        </term>
+        <listitem>
+          <para>
+            <option>Disables all transforming attributes for all files. This is done by
+            defining a macro attribute <symbol>[attr]dgit-defuse-attrs</symbol> and applying it
+            to <filename>*</filename> together with <symbol>export-subst</symbol> and
+            <symbol>export-ignore</symbol>.
+          </para>
+          <para>
+            This method is compatible with <command>dgit</command> and <command>git-deborig</command>
+            which use this macro attribute. Older versions of <command>dgit</command> use an incomplete
+            preset missing some attributes; if such is found, it is replaced by an updated definition.
+          </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term><option>--all</option>
+        </term>
+        <listitem>
+          <para>
+            Apply all known &git; attribute settings. This is the default.
+          </para>
+        </listitem>
+      </varlistentry>
     </variablelist>
   </refsect1>
   <refsect1>

--- a/docs/manpages/gbp-setup-gitattributes.xml
+++ b/docs/manpages/gbp-setup-gitattributes.xml
@@ -1,0 +1,77 @@
+<refentry id="man.gbp.setup.gitattributes">
+  <refentryinfo>
+    <address>
+      <email>andrew@shadura.me</email>
+    </address>
+    <author>
+      <firstname>Andrej</firstname>
+      <surname>Shadura</surname>
+    </author>
+  </refentryinfo>
+  <refmeta><refentrytitle>gbp-setup-gitattributes</refentrytitle>
+    &dhsection;
+  </refmeta>
+  <refnamediv>
+    <refname>gbp-setup-gitattributes</refname>
+    <refpurpose>Set up &git; attributes to disable transformations</refpurpose>
+  </refnamediv>
+  <refsynopsisdiv>
+    <cmdsynopsis>
+      &gbp-setup-gitattributes;
+
+      &man.common.options.synopsis;
+    </cmdsynopsis>
+  </refsynopsisdiv>
+  <refsect1>
+    <title>DESCRIPTION</title>
+    <para>
+      &gbp-setup-gitattributes; sets up <filename>.git/info/attributes</filename> in the current
+      repository to disable all transforming attributes for all files. This is done by defining
+      a macro attribute <symbol>[attr]dgit-defuse-attrs</symbol> and applying it to <filename>*</filename>
+      together with <symbol>export-subst</symbol> and <symbol>export-ignore</symbol>.
+    </para>
+    <para>
+      This method is compatible with <command>dgit</command> and <command>git-deborig</command>
+      which use this macro attribute. Older versions of <command>dgit</command> use an incomplete
+      preset missing some attributes; if such is found, it is replaced by an updated definition.
+    </para>
+    <para>
+      Disabling those attributes is necessary, since they cause often unwanted conversion of files
+      on checkout (e.g. line endings, encodings, etc). Working with such source tree is confusing,
+      since the working tree differs from the Git history (and sometimes from the source tarball),
+      and can lead to errors.
+    </para>
+    <para>
+      By default, &gbp-clone; tries to detect the usage of <filename>.gitattributes</filename> in the
+      upstream source and disable the Git attributes only when necessary.
+    </para>
+  </refsect1>
+  <refsect1>
+    <title>OPTIONS</title>
+    <variablelist>
+      &man.common.options.description;
+    </variablelist>
+  </refsect1>
+  <refsect1>
+    <title>SEE ALSO</title>
+    <para>
+      <xref linkend="man.gbp.clone"/>,
+      <xref linkend="man.gbp.push"/>,
+      <xref linkend="man.gbp.conf"/>,
+      <citerefentry>
+        <refentrytitle>gitattributes</refentrytitle>
+        <manvolnum>5</manvolnum>
+      </citerefentry>,
+      <citerefentry>
+        <refentrytitle>dgit</refentrytitle>
+        <manvolnum>7</manvolnum>
+      </citerefentry>
+    </para>
+  </refsect1>
+  <refsect1>
+    <title>AUTHOR</title>
+    <para>
+      Andrej Shadura <email>andrew@shadura.me</email>
+    </para>
+  </refsect1>
+</refentry>

--- a/docs/manpages/manpages.ent
+++ b/docs/manpages/manpages.ent
@@ -19,6 +19,7 @@
 <!ENTITY man.gbp.pull SYSTEM "gbp-pull.xml">
 <!ENTITY man.gbp.push SYSTEM "gbp-push.xml">
 <!ENTITY man.gbp.rpm.ch SYSTEM "gbp-rpm-ch.xml">
+<!ENTITY man.gbp.setup.gitattributes SYSTEM "gbp-setup-gitattributes.xml">
 <!ENTITY man.gbp.tag SYSTEM "gbp-tag.xml">
 <!ENTITY man.seealso.common SYSTEM "man.seealso.xml">
 

--- a/gbp/config.py
+++ b/gbp/config.py
@@ -121,6 +121,7 @@ class GbpOptionParser(OptionParser):
                 'debian-branch': 'master',
                 'debian-tag': 'debian/%(version)s',
                 'debian-tag-msg': '%(pkg)s Debian release %(version)s',
+                'defuse-gitattributes': 'auto',
                 'dist': 'sid',
                 'drop': 'False',
                 'export': 'HEAD',

--- a/gbp/git/repository.py
+++ b/gbp/git/repository.py
@@ -1071,8 +1071,8 @@ class GitRepository(object):
 
     def list_tree(self, treeish, recurse=False, paths=None):
         """
-        Get a trees content. It returns a list of objects that match the
-        'ls-tree' output: [mode, type, sha1, path].
+        Get a trees content. It yields tuples that match the
+        'ls-tree' output: (mode, type, sha1, path).
 
         @param treeish: the treeish object to list
         @type treeish: C{str}
@@ -1091,15 +1091,13 @@ class GitRepository(object):
         if ret:
             raise GitRepositoryError("Failed to ls-tree '%s': '%s'" % (treeish, err.decode().strip()))
 
-        tree = []
         for line in out.split(b'\0'):
             if line:
                 parts = line.split(None, 3)
                 # decode everything but the file name
-                for i in range(len(parts) - 1):
-                    parts[i] = parts[i].decode()
-                tree.append(parts)
-        return tree
+                filename = parts.pop()
+                mode, type, sha1 = (part.decode() for part in parts)
+                yield mode, type, sha1, filename
 
 #}
 

--- a/gbp/scripts/clone.py
+++ b/gbp/scripts/clone.py
@@ -138,6 +138,8 @@ def build_parser(name):
                                   choices=['DEBIAN', 'GIT'])
     parser.add_config_file_option(option_name="repo-email", dest="repo_email",
                                   choices=['DEBIAN', 'GIT'])
+    parser.add_config_file_option(option_name="defuse-gitattributes", dest="defuse_gitattributes",
+                                  type="tristate", help="disable harmful Git attributes")
     return parser
 
 
@@ -208,6 +210,9 @@ def main(argv):
             repo.set_branch(options.debian_branch)
 
         repo_setup.set_user_name_and_email(options.repo_user, options.repo_email, repo)
+        if not options.defuse_gitattributes.is_off():
+            if options.defuse_gitattributes.is_on() or not repo_setup.check_gitattributes(repo, 'HEAD'):
+                repo_setup.setup_gitattributes(repo)
 
         if postclone:
             Hook('Postclone', options.postclone,

--- a/gbp/scripts/common/repo_setup.py
+++ b/gbp/scripts/common/repo_setup.py
@@ -1,6 +1,8 @@
 # vim: set fileencoding=utf-8 :
 #
 # (C) 2006-2011, 2016 Guido Günther <agx@sigxcpu.org>
+# (C) 2021 Andrej Shadura <andrew@shadura.me>
+# (C) 2021 Collabora Limited
 #    This program is free software; you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
 #    the Free Software Foundation; either version 2 of the License, or
@@ -18,6 +20,10 @@
 """Common repository setup functionality."""
 
 import os
+import re
+import gbp.log
+
+from pathlib import Path
 
 
 def set_user_name_and_email(repo_user, repo_email, repo):
@@ -28,3 +34,91 @@ def set_user_name_and_email(repo_user, repo_email, repo):
     if repo_email == 'DEBIAN':
         if os.getenv('DEBEMAIL'):
             repo.set_user_email(os.getenv('DEBEMAIL'))
+
+
+def check_gitattributes(repo, treeish) -> bool:
+    """
+    Verify the treeish doesn’t contain non-empty .gitattributes files.
+    """
+    for mode, _type, sha1, size, path in repo.list_tree(treeish, recurse=True, sizes=True):
+        if size == 0:
+            continue
+        if path == b'.gitattributes' or path.endswith(b'/.gitattributes'):
+            gbp.log.debug("Found non-empty .gitattributes: %s" % path)
+            return False
+    return True
+
+
+dgit_attr_macro_re = re.compile(r'^\[attr\]dgit-defuse-attrs\s')
+dgit_attr_macro_defn = '-text -eol -crlf -ident -filter -working-tree-encoding'
+attr_glob_defns = {
+    'dgit-defuse-attrs',
+    '-export-subst',
+    '-export-ignore',
+}
+
+
+def is_gitattributes_set_up(repo) -> bool:
+    """
+    Return True if git attributes have been set up correctly:
+        * dgit-defuse-attrs macro exists
+        * dgit-defuse-attrs includes attributes we’re interested in
+        * dgit-defuse-attrs is enabled for *
+        * export-subst and export-ignore are unset for *
+    """
+    gitattrs = Path(repo.git_dir) / 'info' / 'attributes'
+    if not gitattrs.exists():
+        return False
+    dgit_macro_present = False
+    attrs = set()
+    for line in gitattrs.read_text().splitlines():
+        if dgit_attr_macro_re.match(line):
+            gbp.log.debug("Found Git attribute macro: %s" % line)
+            dgit_macro_present = line.endswith(dgit_attr_macro_defn)
+            continue
+        attr = line.split()
+        if attr[0] == '*' and len(attr) == 2:
+            attrs.add(attr[1])
+    gbp.log.debug("Found global Git attributes: %s" % ', '.join(attrs))
+    return dgit_macro_present and attrs >= attr_glob_defns
+
+
+def setup_gitattributes(repo, treeish='HEAD'):
+    """
+    Setup .git/info/attributes in a way to prevent transformations from interfering
+    with packaging, because the working tree files can differ from the Git revision
+    history (and from the source packages).
+
+    Similar functionality has been implemented by dgit and git-deborig, so we try
+    to stay compatible and re-use the name of the attribute macro. Since dgit doesn’t
+    disable export-subst and export-ignore, which may interfere with export-orig, we
+    add this on top the same way git-deborig does.
+    """
+    if is_gitattributes_set_up(repo):
+        return
+    gbp.log.debug("Configuring Git attributes")
+    gitattrs = Path(repo.git_dir) / 'info' / 'attributes'
+    new_attributes = []
+    if not gitattrs.exists():
+        gitattrs.parent.mkdir(exist_ok=True)
+    else:
+        for line in gitattrs.read_text().splitlines():
+            attr = line.split()
+            if attr[0] == '*' and len(attr) == 2:
+                if attr[1] in attr_glob_defns:
+                    continue
+            if dgit_attr_macro_re.match(line):
+                new_attributes += [
+                    "# Old dgit macro disabled:",
+                    "# %s" % line,
+                ]
+                gbp.log.debug("Disabling old dgit macro: '%s'" % line)
+            else:
+                new_attributes.append(line)
+    new_attributes += [
+        "# Added by git-buildpackage to disable .gitattributes found in the upstream tree",
+        "[attr]dgit-defuse-attrs  %s" % dgit_attr_macro_defn,
+    ] + ['* %s' % attr for attr in attr_glob_defns]
+    with gitattrs.with_suffix('.new') as newattrs:
+        newattrs.write_text('\n'.join(new_attributes))
+        newattrs.rename(gitattrs)

--- a/gbp/scripts/setup_gitattributes.py
+++ b/gbp/scripts/setup_gitattributes.py
@@ -1,0 +1,90 @@
+# vim: set fileencoding=utf-8 :
+#
+# (C) 2021 Andrej Shadura <andrew@shadura.me>
+# (C) 2021 Collabora Limited
+#    This program is free software; you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation; either version 2 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program; if not, please see
+#    <http://www.gnu.org/licenses/>
+#
+"""Setup Git attributes to incapacitate .gitattributes shipped by the upstream"""
+
+import os
+import sys
+import gbp.log
+from gbp.command_wrappers import CommandExecFailed
+from gbp.config import GbpOptionParserDebian
+from gbp.deb.git import GitRepositoryError, DebianGitRepository
+from gbp.errors import GbpError
+from gbp.scripts.common import ExitCodes
+from gbp.scripts.common.repo_setup import setup_gitattributes
+
+
+def build_parser(name):
+    try:
+        parser = GbpOptionParserDebian(command=os.path.basename(name), prefix='',
+                                       usage='%prog - disable harmful Git attributes')
+    except GbpError as err:
+        gbp.log.err(err)
+        return None
+
+    parser.add_option("--verbose", action="store_true", dest="verbose",
+                      default=False, help="verbose command execution")
+    parser.add_config_file_option(option_name="color", dest="color",
+                                  type='tristate')
+    parser.add_config_file_option(option_name="color-scheme",
+                                  dest="color_scheme")
+
+    return parser
+
+
+def parse_args(argv):
+    """Parse the command line arguments
+    @return: options and arguments
+    """
+
+    parser = build_parser(argv[0])
+    if not parser:
+        return None, None
+
+    (options, args) = parser.parse_args(argv[1:])
+    gbp.log.setup(options.color, options.verbose, options.color_scheme)
+    return options, args
+
+
+def main(argv):
+    repo = None
+
+    (options, args) = parse_args(argv)
+    if not options:
+        return ExitCodes.parse_error
+
+    try:
+        try:
+            repo = DebianGitRepository('.')
+        except GitRepositoryError:
+            raise GbpError("%s is not a git repository" % (os.path.abspath('.')))
+
+        setup_gitattributes(repo)
+    except (GitRepositoryError, GbpError, CommandExecFailed) as err:
+        if str(err):
+            gbp.log.err(err)
+    except KeyboardInterrupt:
+        gbp.log.err("Interrupted. Aborting.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))
+
+# vim:et:ts=4:sw=4:et:sts=4:ai:set list listchars=tab\:»·,trail\:·:

--- a/tests/component/deb/test_clone.py
+++ b/tests/component/deb/test_clone.py
@@ -82,3 +82,48 @@ class TestClone(ComponentTestBase):
         self.assertEquals(ret, 0)
         cloned = ComponentTestGitRepository(dest)
         self._check_repo_state(cloned, 'master', ['master'])
+
+    @RepoFixtures.native()
+    def test_clone_without_attrs(self, repo):
+        """Test that cloning a repo without harmful attrs does nothing"""
+        dest = os.path.join(self._tmpdir,
+                            'cloned_repo')
+        clone(['arg0',
+               repo.path, dest])
+        cloned = ComponentTestGitRepository(dest)
+        self._check_repo_state(cloned, 'master', ['master'])
+
+        attrs_file = os.path.join(dest, '.git', 'info', 'attributes')
+        # file may be empty or absent
+        self.assertFalse(os.path.exists(attrs_file) and os.path.getsize(attrs_file),
+                         "%s is non-empty" % attrs_file)
+
+    @RepoFixtures.native()
+    def test_clone_with_attrs(self, repo):
+        """Test that cloning a repo with harmful attrs disarms them"""
+        with open('.gitattributes', 'w') as f:
+            f.write('# not empty')
+        repo.add_files('.gitattributes')
+        repo.commit_files('.gitattributes', msg="add .gitattributes")
+
+        dest = os.path.join(self._tmpdir,
+                            'cloned_repo')
+        clone(['arg0',
+               repo.path, dest])
+        cloned = ComponentTestGitRepository(dest)
+        self._check_repo_state(cloned, 'master', ['master'])
+
+        attrs_file = os.path.join(dest, '.git', 'info', 'attributes')
+        ok_(os.path.exists(attrs_file), "%s is missing" % attrs_file)
+
+        with open(attrs_file) as f:
+            attrs = sorted(f.read().splitlines())
+
+        expected_gitattrs = [
+            '# Added by git-buildpackage to disable .gitattributes found in the upstream tree',
+            '* -export-ignore',
+            '* -export-subst',
+            '* dgit-defuse-attrs',
+            '[attr]dgit-defuse-attrs  -text -eol -crlf -ident -filter -working-tree-encoding',
+        ]
+        self.assertEquals(attrs, expected_gitattrs)

--- a/tests/component/deb/test_setup_gitattributes.py
+++ b/tests/component/deb/test_setup_gitattributes.py
@@ -1,0 +1,177 @@
+# vim: set fileencoding=utf-8 :
+#
+# (C) 2021 Andrej Shadura <andrew@shadura.me>
+# (C) 2021 Collabora Limited
+#
+#    This program is free software; you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation; either version 2 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program; if not, please see
+#    <http://www.gnu.org/licenses/>
+
+import os
+
+from tests.component import (ComponentTestBase,
+                             ComponentTestGitRepository)
+from tests.component.deb.fixtures import RepoFixtures
+
+from nose.tools import ok_
+
+from gbp.scripts.clone import main as clone
+from gbp.scripts.setup_gitattributes import main as setup_gitattributes
+
+
+sorted_gitattrs = [
+    '# Added by git-buildpackage to disable .gitattributes found in the upstream tree',
+    '* -export-ignore',
+    '* -export-subst',
+    '* dgit-defuse-attrs',
+    '[attr]dgit-defuse-attrs  -text -eol -crlf -ident -filter -working-tree-encoding',
+]
+
+
+dgit_attributes = [
+    '*\tdgit-defuse-attrs',
+    '[attr]dgit-defuse-attrs\t-text -eol -crlf -ident -filter -working-tree-encoding',
+    '# ^ see GITATTRIBUTES in dgit(7) and dgit setup-new-tree in dgit(1)'
+]
+
+
+dgit34_attributes = [
+    '*\tdgit-defuse-attrs',
+    '[attr]dgit-defuse-attrs\t-text -eol -crlf -ident -filter',
+    '# ^ see dgit(7).  To undo, leave a definition of [attr]dgit-defuse-attrs'
+]
+
+
+class TestSetupGitattributes(ComponentTestBase):
+    """Test setting up Git attributes"""
+
+    @RepoFixtures.native()
+    def test_setup_gitattrs_do_nothing(self, repo):
+        """Test that disabling all knows presets works and gives an error"""
+        dest = os.path.join(self._tmpdir,
+                            'cloned_repo')
+        clone(['arg0',
+               repo.path, dest])
+        cloned = ComponentTestGitRepository(dest)
+        self._check_repo_state(cloned, 'master', ['master'])
+
+        attrs_file = os.path.join(dest, '.git', 'info', 'attributes')
+
+        # file shouldn’t exist at this point yet
+        self.assertFalse(os.path.exists(attrs_file) and os.path.getsize(attrs_file),
+                         "%s is non-empty" % attrs_file)
+
+        os.chdir(cloned.path)
+        setup_gitattributes(['arg0', '--no-dgit-defuse-attrs'])
+
+        # file shouldn’t exist at this point yet
+        self.assertFalse(os.path.exists(attrs_file) and os.path.getsize(attrs_file),
+                         "%s is non-empty" % attrs_file)
+
+        self._check_log(-1,
+                        "gbp:error: Nothing to do, no settings to apply.")
+
+    @RepoFixtures.native()
+    def test_setup_gitattrs(self, repo):
+        """Test that setting up Git attributes manually works"""
+        dest = os.path.join(self._tmpdir,
+                            'cloned_repo')
+        clone(['arg0',
+               repo.path, dest])
+        cloned = ComponentTestGitRepository(dest)
+        self._check_repo_state(cloned, 'master', ['master'])
+
+        attrs_file = os.path.join(dest, '.git', 'info', 'attributes')
+
+        # file shouldn’t exist at this point yet
+        self.assertFalse(os.path.exists(attrs_file) and os.path.getsize(attrs_file),
+                         "%s is non-empty" % attrs_file)
+
+        os.chdir(cloned.path)
+        setup_gitattributes(['arg0'])
+
+        ok_(os.path.exists(attrs_file), "%s is missing" % attrs_file)
+
+        with open(attrs_file) as f:
+            attrs = sorted(f.read().splitlines())
+        self.assertEquals(attrs, sorted_gitattrs)
+
+    @RepoFixtures.native()
+    def test_setup_gitattrs_dgit(self, repo):
+        """Test that setting up Git attributes manually works even with dgit"""
+        dest = os.path.join(self._tmpdir,
+                            'cloned_repo')
+        clone(['arg0',
+               repo.path, dest])
+        cloned = ComponentTestGitRepository(dest)
+        self._check_repo_state(cloned, 'master', ['master'])
+
+        attrs_file = os.path.join(dest, '.git', 'info', 'attributes')
+
+        # file shouldn’t exist at this point yet
+        self.assertFalse(os.path.exists(attrs_file) and os.path.getsize(attrs_file),
+                         "%s is non-empty" % attrs_file)
+
+        with open(attrs_file, 'w') as f:
+            f.write('\n'.join(dgit_attributes))
+
+        os.chdir(cloned.path)
+        setup_gitattributes(['arg0', '--verbose'])
+
+        ok_(os.path.exists(attrs_file), "%s is missing" % attrs_file)
+
+        with open(attrs_file) as f:
+            attrs = sorted(f.read().splitlines())
+
+        expected_gitattrs = sorted(sorted_gitattrs + [
+            '# Old dgit macro disabled:',
+            '# [attr]dgit-defuse-attrs\t-text -eol -crlf -ident -filter -working-tree-encoding',
+            '# ^ see GITATTRIBUTES in dgit(7) and dgit setup-new-tree in dgit(1)',
+        ])
+
+        self.assertEquals(attrs, expected_gitattrs)
+
+    @RepoFixtures.native()
+    def test_setup_gitattrs_dgit34(self, repo):
+        """Test that setting up Git attributes manually works even with a very old dgit"""
+        dest = os.path.join(self._tmpdir,
+                            'cloned_repo')
+        clone(['arg0',
+               repo.path, dest])
+        cloned = ComponentTestGitRepository(dest)
+        self._check_repo_state(cloned, 'master', ['master'])
+
+        attrs_file = os.path.join(dest, '.git', 'info', 'attributes')
+
+        # file shouldn’t exist at this point yet
+        self.assertFalse(os.path.exists(attrs_file) and os.path.getsize(attrs_file),
+                         "%s is non-empty" % attrs_file)
+
+        with open(attrs_file, 'w') as f:
+            f.write('\n'.join(dgit34_attributes))
+
+        os.chdir(cloned.path)
+        setup_gitattributes(['arg0', '--verbose'])
+
+        ok_(os.path.exists(attrs_file), "%s is missing" % attrs_file)
+
+        with open(attrs_file) as f:
+            attrs = sorted(f.read().splitlines())
+
+        expected_gitattrs = sorted(sorted_gitattrs + [
+            '# Old dgit macro disabled:',
+            '# [attr]dgit-defuse-attrs\t-text -eol -crlf -ident -filter',
+            '# ^ see dgit(7).  To undo, leave a definition of [attr]dgit-defuse-attrs',
+        ])
+
+        self.assertEquals(attrs, expected_gitattrs)

--- a/tests/doctests/test_GitRepository.py
+++ b/tests/doctests/test_GitRepository.py
@@ -951,6 +951,8 @@ def test_make_tree():
     '745951810c9e22fcc6de9b23f05efd6ab5512123'
     >>> list(repo.list_tree(newtree, recurse=False, paths='testfile'))
     [('100644', 'blob', '19af7398c894bc5e86e17259317e4db519e9241f', b'testfile')]
+    >>> list(repo.list_tree(newtree, recurse=False, paths='testfile', sizes=True))
+    [('100644', 'blob', '19af7398c894bc5e86e17259317e4db519e9241f', 20, b'testfile')]
     >>> repo.make_tree([])
     '4b825dc642cb6eb9a060e54bf8d69288fbee4904'
     """

--- a/tests/doctests/test_GitRepository.py
+++ b/tests/doctests/test_GitRepository.py
@@ -942,15 +942,15 @@ def test_make_tree():
     >>> sha1 = repo.write_file('testfile')
     >>> sha1
     '19af7398c894bc5e86e17259317e4db519e9241f'
-    >>> head = repo.list_tree('HEAD')
+    >>> head = list(repo.list_tree('HEAD'))
     >>> head
-    [['100644', 'blob', '19af7398c894bc5e86e17259317e4db519e9241f', b'testfile']]
+    [('100644', 'blob', '19af7398c894bc5e86e17259317e4db519e9241f', b'testfile')]
     >>> head.append(['100644', 'blob', '19af7398c894bc5e86e17259317e4db519e9241f', 'testfile2'])
     >>> newtree = repo.make_tree(head)
     >>> newtree
     '745951810c9e22fcc6de9b23f05efd6ab5512123'
-    >>> repo.list_tree(newtree, recurse=False, paths='testfile')
-    [['100644', 'blob', '19af7398c894bc5e86e17259317e4db519e9241f', b'testfile']]
+    >>> list(repo.list_tree(newtree, recurse=False, paths='testfile'))
+    [('100644', 'blob', '19af7398c894bc5e86e17259317e4db519e9241f', b'testfile')]
     >>> repo.make_tree([])
     '4b825dc642cb6eb9a060e54bf8d69288fbee4904'
     """


### PR DESCRIPTION
This is a work-in-progress implementation which would fix the Debian bug: [#973755](https://bugs.debian.org/973755).

Please see more about the motivation in the bug itself, [dgit(7)](https://manpages.debian.org/buster/dgit/dgit.7.en.html#GITATTRIBUTES), [git-deborig(1)](https://manpages.debian.org/buster/devscripts/git-deborig.1.en.html) and in the commit messages of the individual commits.

I posted this WIP PR to get comments on the general direction of work. I will be adding tests if you approve the approach I’ve taken.