### PR TITLE
dch: Add support for the --local=suffix option

### DIFF
--- a/debian/git-buildpackage.zsh-completion
+++ b/debian/git-buildpackage.zsh-completion
@@ -154,6 +154,7 @@ _gbp-dch () {
 		'--bpo[Increment the release number for a backports upload]' \
 		'--nmu[Increment the release number for a NMU upload]' \
 		'--qa[Increment the release number for a QA upload]' \
+		'(--local -l)'{-l,--local}'=-[Increment the release number for a local build]' \
 		'--distribution=-[Set the distribution field]' \
 		'--force-distribution[Force distribution]' \
 		'--urgency=-[Set the upload urgency]' \

--- a/docs/manpages/gbp-dch.xml
+++ b/docs/manpages/gbp-dch.xml
@@ -49,6 +49,7 @@
         <arg><option>--qa</option></arg>
         <arg><option>--security</option></arg>
         <arg><option>--team</option></arg>
+        <arg><option>--local=</option><replaceable>suffix</replaceable></arg>
       </group>
       <arg><option>--distribution=</option><replaceable>name</replaceable></arg>
       <arg><option>--force-distribution</option></arg>
@@ -379,6 +380,18 @@
             Increment the Debian release number for a Debian Security
             Team non-maintainer upload, and add a "Security Team
             upload" changelog comment.
+            This option can't be set via &gbp.conf;.
+          </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term><option>--local=</option><replaceable>suffix</replaceable>,
+              <option>-l</option> <replaceable>suffix</replaceable>
+        </term>
+        <listitem>
+          <para>
+            Increment the Debian release number for a local build
+            using the specified suffix.
             This option can't be set via &gbp.conf;.
           </para>
         </listitem>

--- a/gbp/scripts/dch.py
+++ b/gbp/scripts/dch.py
@@ -393,6 +393,8 @@ def build_parser(name):
     version_group.add_option("--security", dest="security", action="store_true", default=False,
                              help="Increment the Debian release number for a security upload and "
                              "add a security upload changelog comment.")
+    version_group.add_option("-l", "--local", dest="local_suffix", metavar="SUFFIX",
+                             help="Add a suffix to the Debian version number for a local build.")
     version_group.add_boolean_config_file_option(option_name="git-author", dest="use_git_author")
     commit_group.add_boolean_config_file_option(option_name="meta", dest="meta")
     commit_group.add_config_file_option(option_name="meta-closes", dest="meta_closes")
@@ -498,7 +500,7 @@ def main(argv):
         add_section = False
         # add a new changelog section if:
         if (options.new_version or options.bpo or options.nmu or options.qa or
-                options.team or options.security):
+                options.team or options.security or options.local_suffix):
             if options.bpo:
                 version_change['increment'] = '--bpo'
             elif options.nmu:
@@ -509,6 +511,8 @@ def main(argv):
                 version_change['increment'] = '--team'
             elif options.security:
                 version_change['increment'] = '--security'
+            elif options.local_suffix:
+                version_change['increment'] = '--local=%s' % options.local_suffix
             else:
                 version_change['version'] = options.new_version
             # the user wants to force a new version

--- a/tests/11_test_dch_main.py
+++ b/tests/11_test_dch_main.py
@@ -304,6 +304,13 @@ class TestScriptDch(DebianGitTestRepo):
         self.assertEqual("test-package (%s) %s; urgency=%s\n" % (new_version_0_9, os_codename, default_urgency), lines[0])
         self.assertIn("""  * added debian/control\n""", lines)
 
+    def test_dch_main_increment_debian_version_with_local(self):
+        """Test dch.py like gbp dch script does: increment debian version - local suffix"""
+        options = ["--local", "suffix"]
+        lines = self.run_dch(options)
+        self.assertEqual("test-package (0.9-1suffix1) UNRELEASED; urgency=%s\n" % (default_urgency,), lines[0])
+        self.assertIn("""  * added debian/control\n""", lines)
+
     def test_dch_main_increment_debian_version_with_auto(self):
         """Test dch.py like gbp dch script does: increment debian version - guess last commit"""
         self.repo.delete_tag("upstream/1.0")


### PR DESCRIPTION
At [apertis.org](https://apertis.org/) we're managing a Debian derivative relying heavily on GitLab pipelines and `git-buildpackage` (so thank you for it!). Our workflow involves appending a local suffix to every package we import to distinguish it from the original sources, since we always re-generate the deb sources.

At the moment we're doing it using `debchange` directly or, worse, by manual editing, but it would be much better to have the `--local` option from `debchange` supported by `gbp dch` so we'd have a much more streamlined workflow. 

This PR would close Debian bug [#857370](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=857370).