### PR TITLE
clone: Don’t check out the Debian branch if it doesn’t exist

### DIFF
--- a/gbp/scripts/clone.py
+++ b/gbp/scripts/clone.py
@@ -204,7 +204,8 @@ def main(argv):
                         not repo.has_branch(branch)):
                     repo.create_branch(branch, remote)
 
-        repo.set_branch(options.debian_branch)
+        if repo.has_branch(options.debian_branch, remote=True):
+            repo.set_branch(options.debian_branch)
 
         repo_setup.set_user_name_and_email(options.repo_user, options.repo_email, repo)
 


### PR DESCRIPTION
This change is originally from PR #75.

By the time `repo.set_branch` runs, we’ve already verified which remote branches exist and which do not, and have set up tracking branches for those which do. However, that set may as well be empty e.g. when the package has been re-imported into Git by a Debian derivative with a different branching scheme (e.g. the package in Debian uses non-DEP-14 branching while the derivative opts for DEP-14). In this case, it would be sensible to only try checking out the Debian branch if it exists, but leave it at the default if it isn’t — rather than erroring out.