### PR TITLE
docs: fix build

### DIFF
--- a/docs/manpages/gbp-setup-gitattributes.xml
+++ b/docs/manpages/gbp-setup-gitattributes.xml
@@ -58,7 +58,7 @@
             <option>Disables all transforming attributes for all files. This is done by
             defining a macro attribute <symbol>[attr]dgit-defuse-attrs</symbol> and applying it
             to <filename>*</filename> together with <symbol>export-subst</symbol> and
-            <symbol>export-ignore</symbol>.
+            <symbol>export-ignore</symbol>.</option>
           </para>
           <para>
             This method is compatible with <command>dgit</command> and <command>git-deborig</command>

--- a/gbp/scripts/common/repo_setup.py
+++ b/gbp/scripts/common/repo_setup.py
@@ -61,10 +61,10 @@ attr_glob_defns = {
 def is_gitattributes_set_up(repo) -> bool:
     """
     Return True if git attributes have been set up correctly:
-        * dgit-defuse-attrs macro exists
-        * dgit-defuse-attrs includes attributes we’re interested in
-        * dgit-defuse-attrs is enabled for *
-        * export-subst and export-ignore are unset for *
+        - dgit-defuse-attrs macro exists
+        - dgit-defuse-attrs includes attributes we’re interested in
+        - dgit-defuse-attrs is enabled for *
+        - export-subst and export-ignore are unset for *
     """
     gitattrs = Path(repo.git_dir) / 'info' / 'attributes'
     if not gitattrs.exists():


### PR DESCRIPTION
`make docs` currently fails because of 2 minor errors. This PR fixes documentation so that build succeeds.