### PR TITLE
Fix import-dsc on empty repo if defaultBranch != master

### DIFF
--- a/gbp/git/repository.py
+++ b/gbp/git/repository.py
@@ -1545,7 +1545,12 @@ class GitRepository(object):
                     raise
         else:  # empty repo
             cur = None
-            branch = 'master'
+            out, _, ret = self._git_inout('symbolic-ref', ['HEAD'],
+                                          capture_stderr=True)
+            if ret:
+                raise GitRepositoryError("Currently not on a branch")
+            ref = out.decode().split('\n')[0]
+            branch = ref[11:]  # strip /refs/heads
 
         # Build list of parents:
         parents = []

--- a/gbp/git/repository.py
+++ b/gbp/git/repository.py
@@ -1119,7 +1119,7 @@ class GitRepository(object):
         """
         value, ret = self._git_getoutput('config', [name])
         if ret:
-            raise KeyError("'%s' not found in git config")
+            raise KeyError("'%s' not found in git config" % name)
         return value[0].decode()[:-1]  # first line with \n ending removed
 
     def set_config(self, name, value):


### PR DESCRIPTION
When importing a dsc on a empty repository when `ìnit.defaultBranch` is
set to something like `main` in `~/.gitconfig` we failed with:

    gbp:debug: ['git', 'update-ref', '-m', 'gbp: Import Upstream version 0.5.10.2', 'refs/heads/master', '95172aee8d1a4e6c69494e4f158f904111710168']
    gbp:debug: ['git', 'symbolic-ref', 'HEAD']
    gbp:debug: ['git', 'show-ref', 'refs/heads/main']
    gbp:debug: ['git', 'symbolic-ref', 'HEAD']
    gbp:debug: ['git', 'show-ref', 'refs/heads/main']
    gbp:debug: ['git', 'branch', '-m', 'None', 'debian/buster']
    gbp:error: Git command failed: Error running git branch: error: refname refs/heads/None not found
    fatal: Branch rename failed
    Traceback (most recent call last):
      File "/usr/local/lib/python3.9/dist-packages/gbp-0.9.22-py3.9.egg/gbp/scripts/import_dsc.py", line 519, in main
        commit = import_upstream(repo, sources[0], dsc, options)
      File "/usr/local/lib/python3.9/dist-packages/gbp-0.9.22-py3.9.egg/gbp/scripts/import_dsc.py", line 269, in import_upstream
        repo.rename_branch(repo.branch, options.debian_branch)
      File "/usr/local/lib/python3.9/dist-packages/gbp-0.9.22-py3.9.egg/gbp/git/repository.py", line 333, in rename_branch
        self._git_command("branch", args.args)
      File "/usr/local/lib/python3.9/dist-packages/gbp-0.9.22-py3.9.egg/gbp/git/repository.py", line 245, in _git_command
        raise GitRepositoryError("Error running git %s: %s" % (command, detail.decode().strip()))
    gbp.git.repository.GitRepositoryError: Error running git branch: error: refname refs/heads/None not found
    fatal: Branch rename failed

That's because we created the commit on `refs/heads/master` and then
tried to rename it from `refs/heads/main`.

To avoid that, if the repository is empty look at the name of the
current branch as reported by the symbolic ref pointed by `HEAD`.

Fixes https://bugs.debian.org/906600