### PR TITLE
pull: Allow pull in unclean repos

### DIFF
--- a/gbp/scripts/pull.py
+++ b/gbp/scripts/pull.py
@@ -177,12 +177,6 @@ def main(argv):
             else:
                 raise
 
-        (ret, out) = repo.is_clean()
-        if not ret:
-            gbp.log.err("You have uncommitted changes in your source tree:")
-            gbp.log.err(out)
-            raise GbpError
-
         repo.fetch(rem_repo, depth=options.depth)
         repo.fetch(rem_repo, depth=options.depth, tags=True)
 


### PR DESCRIPTION
This works just fine when git can fast forward, i.e. with untracked
content or changes in tracked files that are not touched by the commits.
In case fast forward is not possible gbp will complain anyhow.