### PR TITLE
Fix manpage for "gbp pq export --commit"

### DIFF
--- a/docs/manpages/gbp-pq.xml
+++ b/docs/manpages/gbp-pq.xml
@@ -224,7 +224,7 @@
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><option>--export</option></term>
+        <term><option>--commit</option></term>
         <listitem>
           <para>
 	    In case of <option>export</option>, commit


### PR DESCRIPTION
The gbp-pq manpage, in the section describing each option in detail, lists the "--export" option; given context, I believe this should be "--commit" instead. This patch fixes that.