### PR TITLE
Do not pass --symlink to uscan

### DIFF
--- a/gbp/deb/uscan.py
+++ b/gbp/deb/uscan.py
@@ -143,7 +143,7 @@ class Uscan(object):
 
         @returns: C{True} if a new version was downloaded
         """
-        cmd = ['uscan', '--symlink', '--destdir=%s' % destdir, '--dehs']
+        cmd = ['uscan', '--destdir=%s' % destdir, '--dehs']
         if download_version:
             cmd += ['--download-debversion', download_version]
         p = subprocess.Popen(cmd, cwd=self._dir, stdout=subprocess.PIPE)


### PR DESCRIPTION
git-buildpackage will create the appropriate symlinks for pristine-tar anyway,
so there is no need to force uscan to do it and potentially override settings
from the user configuration.
