### PR TITLE
Fix misc spelling

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -63,9 +63,9 @@ Layout
 
 Interfaces
 ----------
-A gbp command in gbp/scripts/<commmand>.py must provide these interfaces:
+A gbp command in gbp/scripts/<command>.py must provide these interfaces:
 
-When one invokes `gbp <command>` gbp/scripts/<commmand>.py is imported by
+When one invokes `gbp <command>` gbp/scripts/<command>.py is imported by
 
     gbp/scripts/supercommand.py
 
@@ -73,7 +73,7 @@ which then invokes it's *main* function with all given command line arguments.
 It is expected to return with the exit status that should be passed back to the
 shell.
 
-When one invokes `gbp config <command>` gbp/scripts/<commmand>.py is imported by
+When one invokes `gbp config <command>` gbp/scripts/<command>.py is imported by
 
     gbp/scripts/config.py
 

--- a/debian/NEWS
+++ b/debian/NEWS
@@ -47,7 +47,7 @@ git-buildpackage (0.4.61) unstable; urgency=low
 
 git-buildpackage (0.4.57) unstable; urgency=low
 
-  git-import-orig dosn't generate changelog entries by default anymore. This
+  git-import-orig doesn't generate changelog entries by default anymore. This
   means you can safely remove --no-dch from all your scripts and config files.
 
   If you want git-import-orig to behave as before add:

--- a/debian/zsh/_gbp
+++ b/debian/zsh/_gbp
@@ -9,7 +9,6 @@ __gbp_common_options() {
 
 	_arguments "--${prefix}verbose[Verbose execution]" \
 		"--${prefix}color=-[Use colored output]:color:(on auto off)"
-
 }
 
 __gbp_branch_options() {
@@ -123,7 +122,7 @@ _gbp-create-remote-repo() {
 	__gbp_common_options
 	_arguments \
 		'--remote-url-pattern=-[Where to create remote repository]' \
-		'--remote-name=-[What  name  git  will use when refering to that repository]' \
+		'--remote-name=-[What  name  git  will use when referring to that repository]' \
 		'--template-dir=-[Template dir to pass to git init]' \
 		'--remote-config=-[Name of config file section to specify params]' \
 		'(--track --no-track)--track[Set up branch tracking]' \
@@ -138,7 +137,7 @@ _gbp-dch () {
 
 	_arguments \
 		'--ignore-branch[build although debian-branch != current branch]' \
-		'--since=-[Start point for reading commits]:commitish:' \
+		'--since=-[Start point for reading commits]:commit-ish:' \
 		'--auto[Guess the last commit documented in the changelog]' \
 		'(--meta --no-meta)--meta[Parse meta tags]' \
 		'(--meta --no-meta)--no-meta[Do not parse meta tags]' \
@@ -244,7 +243,7 @@ _gbp-pull() {
 	_arguments \
 		'--force[Update even non fast-forward]' \
 		'--redo-pq[Rebuild the patch queue]' \
-		'--ignore-branch[Dont care if on a detached state]' \
+		'--ignore-branch[Do not care if on a detached state]' \
 		'--depth=-[Depth for deepening shallow clones]'
 }
 
@@ -368,12 +367,11 @@ _gbp-create-remote-repo() {
 	__gbp_common_options
 	_arguments \
 		'--remote-url-pattern=-[Where to create remote repository]' \
-		'--remote-name=-[What  name  git  will use when refering to that repository]' \
+		'--remote-name=-[What  name  git  will use when referring to that repository]' \
 		'--template-dir=-[Template dir to pass to git init]' \
 		'--remote-config=-[Name of config file section to specify params]' \
 		'(--track --no-track)--track[Set up branch tracking]' \
 		'(--track --no-track)--no-track[Do not set up branch tracking]'
-
 }
 
 _gbp-dch () {
@@ -383,7 +381,7 @@ _gbp-dch () {
 
 	_arguments \
 		'--ignore-branch[build although debian-branch != current branch]' \
-		'--since=-[Start point for reading commits]:commitish:' \
+		'--since=-[Start point for reading commits]:commit-ish:' \
 		'--auto[Guess the last commit documented in the changelog]' \
 		'(--meta --no-meta)--meta[Parse meta tags]' \
 		'(--meta --no-meta)--no-meta[Do not parse meta tags]' \
@@ -489,7 +487,7 @@ _gbp-pull() {
 		'--all[Update all remote-tracking branches that have identical name in the remote]' \
 		'--depth=-[Depth for deepening shallow clones]' \
 		'--force[Update even non fast-forward]' \
-		'--ignore-branch[Dont care if on a detached state]' \
+		'--ignore-branch[Do not care if on a detached state]' \
 		'--no-ignore-branch[Negates --ignore-branch]' \
 		'--no-pristine-tar[Negates --pristine-tar]' \
 		'--no-track-missing[Negates --track-missing]' \
@@ -503,7 +501,7 @@ _gbp-push() {
 	__gbp_tag_format_options
 	_arguments \
 		'--dry-run[Dry run, do not push]' \
-		'--ignore-branch[Dont care if on a detached state]' \
+		'--ignore-branch[Do not care if on a detached state]' \
 		'--no-ignore-branch[Negates --ignore-branch]'
 }
 
@@ -556,7 +554,7 @@ _gbp-tag() {
 		"--debian-tag=-[Format string for debian tags]" \
 		"--debian-tag-msg=-[Format string for signed debian-tag messages]" \
 		'--git-no-ignore-branch[Negates --git-ignore-branch]' \
-		'--ignore-branch[Dont care if on a detached state]' \
+		'--ignore-branch[Do not care if on a detached state]' \
 		'--ignore-new[Build with uncommitted changes in the source tree]' \
 		'--no-ignore-new[Negates --git-ignore-new]' \
 		'--posttag=-[Hook run after a successful tag operation]:command:' \

--- a/docs/chapters/cfgfile.xml
+++ b/docs/chapters/cfgfile.xml
@@ -109,7 +109,7 @@
       can be used to override configuration entries shipped by the
       package. This can be useful if packages set
       e.g. <option>export-dir</option> or
-      <option>tarball-dir</option> and you perfer different locations:
+      <option>tarball-dir</option> and you prefer different locations:
       <programlisting>
 	$ cat &lt;&lt;EOF &gt;~/.gbp.late.conf
 	[DEFAULT]

--- a/docs/chapters/patches.xml
+++ b/docs/chapters/patches.xml
@@ -47,7 +47,7 @@
 
   <para>
     The main drawback of this workflow is the lack of history on the
-    patch-queue branch since it is frequently droppend and
+    patch-queue branch since it is frequently dropped and
     recreated. But there is full history on
     the your &debian-branch;, of course.
   </para>

--- a/docs/chapters/special.xml
+++ b/docs/chapters/special.xml
@@ -244,7 +244,7 @@ mkdir -p ~/.config/pk4/hooks-enabled/unpack/
 ln -s /usr/share/pk4/hooks-available/unpack/gbp ~/.config/pk4/hooks-enabled/unpack/
       </programlisting>
       <para>
-	This will make sure packages are imported into a git respository after download.
+	This will make sure packages are imported into a git repository after download.
       </para>
     </sect1>
 </chapter>

--- a/docs/manpages/gbp-dch.xml
+++ b/docs/manpages/gbp-dch.xml
@@ -26,8 +26,8 @@
       <arg><option>--upstream-tag=</option><replaceable>tag-format</replaceable></arg>
       <arg><option>--ignore-branch</option></arg>
       <group>
-	<arg><option>-s</option> <replaceable>commitish</replaceable></arg>
-        <arg><option>--since=</option><replaceable>commitish</replaceable></arg>
+	<arg><option>-s</option> <replaceable>commit-ish</replaceable></arg>
+        <arg><option>--since=</option><replaceable>commit-ish</replaceable></arg>
       </group>
       <group>
 	<group>
@@ -96,7 +96,7 @@
       <listitem><para>The start commit is read from the snapshot banner (see below for
       details)</para></listitem>
       <listitem><para>If the topmost version of the
-      <filename>debian/changelog</filename> is alread tagged. Use the commit
+      <filename>debian/changelog</filename> is already tagged. Use the commit
       the tag points to as start commit.</para></listitem>
       <listitem><para>The last commit that modified <filename>debian/changelog</filename> is
       used as start commit.</para></listitem>
@@ -200,12 +200,12 @@
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><option>--since=</option><replaceable>committish</replaceable>
+        <term><option>--since=</option><replaceable>commit-ish</replaceable>
         </term>
         <listitem>
           <para>
             Start reading commit messages at
-            <replaceable>committish</replaceable>.
+            <replaceable>commit-ish</replaceable>.
             This option can't be set via &gbp.conf;.
           </para>
         </listitem>

--- a/docs/manpages/gbp-import-ref.xml
+++ b/docs/manpages/gbp-import-ref.xml
@@ -216,7 +216,7 @@
     <screen>
     &gbp-import-ref; --upstream-tree=BRANCH -u0.0~git20180524</screen>
     <para>
-      Merge commits from the the tag corresponding to version <replaceable>1.0</replaceable>:
+      Merge commits from the tag corresponding to version <replaceable>1.0</replaceable>:
     </para>
     <screen>
     &gbp-import-ref; --upstream-tree=VERSION -u1.0</screen>

--- a/docs/manpages/gbp-push.xml
+++ b/docs/manpages/gbp-push.xml
@@ -82,7 +82,7 @@
     <para>
       If a <replaceable>remote</replaceable> is given on the command line
       the changes are pushed to the given remote repository. By
-      default it will push to the current branchs remote and fall
+      default it will push to the current branches remote and fall
       back to <emphasis>origin</emphasis>.
     </para>
   </refsect1>

--- a/docs/manpages/gbp-rpm-ch.xml
+++ b/docs/manpages/gbp-rpm-ch.xml
@@ -28,7 +28,7 @@
       <arg><option>--packaging-dir=</option><replaceable>DIRECTORY</replaceable></arg>
       <arg><option>--changelog-file=</option><replaceable>FILEPATH</replaceable></arg>
       <arg><option>--spec-file=</option><replaceable>FILEPATH</replaceable></arg>
-      <arg><option>--since=</option><replaceable>COMMITISH</replaceable></arg>
+      <arg><option>--since=</option><replaceable>COMMIT-ISH</replaceable></arg>
       <arg><option>--no-release</option></arg>
       <arg><option>--[no-]git-author</option></arg>
       <arg><option>--[no-]full</option></arg>
@@ -152,12 +152,12 @@
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><option>--since=</option><replaceable>COMMITTISH</replaceable>
+        <term><option>--since=</option><replaceable>COMMIT-ISH</replaceable>
         </term>
         <listitem>
           <para>
           Start reading commit messages at
-          <replaceable>COMMITTISH</replaceable>.
+          <replaceable>COMMIT-ISH</replaceable>.
           </para>
         </listitem>
       </varlistentry>

--- a/docs/po/de.po
+++ b/docs/po/de.po
@@ -690,7 +690,7 @@ msgid ""
 "filename> is at the very end of the list it can be used to override "
 "configuration entries shipped by the package. This can be useful if packages "
 "set e.g. <option>export-dir</option> or <option>tarball-dir</option> and you "
-"perfer different locations: <placeholder type=\"programlisting\" id=\"0\"/>"
+"prefer different locations: <placeholder type=\"programlisting\" id=\"0\"/>"
 msgstr ""
 
 #. type: Content of: <chapter><sect1><para><programlisting>
@@ -1680,7 +1680,7 @@ msgstr ""
 msgid ""
 "The basic idea is that patches are imported from your &debian-branch; to a "
 "patch-queue branch with one patch file in <filename>debian/patches/</"
-"filename> becoming one commit on the the patch-queue branch.  The created "
+"filename> becoming one commit on the patch-queue branch.  The created "
 "branch will be named after the branch you imported from with <filename>patch-"
 "queue/</filename> prepended. So if you do your &debian; packaging on "
 "<filename>debian/sid</filename> and do a"
@@ -1725,7 +1725,7 @@ msgstr ""
 #: chapters/patches.xml:49
 msgid ""
 "The main drawback of this workflow is the lack of history on the patch-queue "
-"branch since it is frequently droppend and recreated. But there is full "
+"branch since it is frequently dropped and recreated. But there is full "
 "history on the your &debian-branch;, of course."
 msgstr ""
 
@@ -2866,7 +2866,7 @@ msgstr ""
 #. type: Content of: <chapter><sect1><para>
 #: chapters/special.xml:247
 msgid ""
-"This will make sure packages are imported into a git respository after "
+"This will make sure packages are imported into a git repository after "
 "download."
 msgstr ""
 
@@ -5432,8 +5432,8 @@ msgid ""
 "upstream-branch=</option><replaceable>branch_name</replaceable></arg> "
 "<arg><option>--upstream-tag=</option><replaceable>tag-format</replaceable></"
 "arg> <arg><option>--ignore-branch</option></arg> <group> <arg><option>-s</"
-"option> <replaceable>commitish</replaceable></arg> <arg><option>--since=</"
-"option><replaceable>commitish</replaceable></arg> </group> <group> <group> "
+"option> <replaceable>commit-ish</replaceable></arg> <arg><option>--since=</"
+"option><replaceable>commit-ish</replaceable></arg> </group> <group> <group> "
 "<arg><option>-S</option></arg> <arg><option>--snapshot</option></arg> </"
 "group> <group> <arg><option>-R</option></arg> <arg><option>--release</"
 "option></arg> </group> </group> <group> <arg><option>-N</option> "
@@ -5487,7 +5487,7 @@ msgstr ""
 #: manpages/gbp-dch.xml:98
 msgid ""
 "If the topmost version of the <filename>debian/changelog</filename> is "
-"alread tagged. Use the commit the tag points to as start commit."
+"already tagged. Use the commit the tag points to as start commit."
 msgstr ""
 
 #. type: Content of: <refentry><refsect1><orderedlist><listitem><para>
@@ -5523,7 +5523,7 @@ msgstr ""
 #. type: Content of: <refentry><refsect1><para>
 #: manpages/gbp-dch.xml:123
 msgid ""
-"To restrict the selected changes even further you can use use the <option>--"
+"To restrict the selected changes even further you can use the <option>--"
 "git-log</option> option which is passed on verbatim to <command>git log</"
 "command>. E.g. by using <option>--git-log=</option><replaceable>\"--"
 "author=Foo Bar\"</replaceable>."
@@ -5584,13 +5584,13 @@ msgstr ""
 
 #. type: Content of: <refentry><refsect1><variablelist><varlistentry><term>
 #: manpages/gbp-dch.xml:203
-msgid "<option>--since=</option><replaceable>committish</replaceable>"
+msgid "<option>--since=</option><replaceable>commit-ish</replaceable>"
 msgstr ""
 
 #. type: Content of: <refentry><refsect1><variablelist><varlistentry><listitem><para>
 #: manpages/gbp-dch.xml:207
 msgid ""
-"Start reading commit messages at <replaceable>committish</replaceable>.  "
+"Start reading commit messages at <replaceable>commit-ish</replaceable>.  "
 "This option can't be set via &gbp.conf;."
 msgstr ""
 
@@ -7263,7 +7263,7 @@ msgstr ""
 #. type: Content of: <refentry><refsect1><para>
 #: manpages/gbp-import-ref.xml:219
 msgid ""
-"Merge commits from the the tag corresponding to version <replaceable>1.0</"
+"Merge commits from the tag corresponding to version <replaceable>1.0</"
 "replaceable>:"
 msgstr ""
 
@@ -8334,7 +8334,7 @@ msgstr ""
 msgid ""
 "If a <replaceable>remote</replaceable> is given on the command line the "
 "changes are pushed to the given remote repository. By default it will push "
-"to the current branchs remote and fall back to <emphasis>origin</emphasis>."
+"to the current branches remote and fall back to <emphasis>origin</emphasis>."
 msgstr ""
 
 #. type: Content of: <refentry><refsect1><variablelist><varlistentry><listitem><para>
@@ -8425,7 +8425,7 @@ msgid ""
 "option><replaceable>DIRECTORY</replaceable></arg> <arg><option>--changelog-"
 "file=</option><replaceable>FILEPATH</replaceable></arg> <arg><option>--spec-"
 "file=</option><replaceable>FILEPATH</replaceable></arg> <arg><option>--"
-"since=</option><replaceable>COMMITISH</replaceable></arg> <arg><option>--no-"
+"since=</option><replaceable>COMMIT-ISH</replaceable></arg> <arg><option>--no-"
 "release</option></arg> <arg><option>--[no-]git-author</option></arg> "
 "<arg><option>--[no-]full</option></arg> <arg><option>--id-length=</"
 "option><replaceable>NUMBER</replaceable></arg> <arg><option>--ignore-regex=</"
@@ -8497,12 +8497,12 @@ msgstr ""
 
 #. type: Content of: <refentry><refsect1><variablelist><varlistentry><term>
 #: manpages/gbp-rpm-ch.xml:155
-msgid "<option>--since=</option><replaceable>COMMITTISH</replaceable>"
+msgid "<option>--since=</option><replaceable>COMMIT-ISH</replaceable>"
 msgstr ""
 
 #. type: Content of: <refentry><refsect1><variablelist><varlistentry><listitem><para>
 #: manpages/gbp-rpm-ch.xml:159
-msgid "Start reading commit messages at <replaceable>COMMITTISH</replaceable>."
+msgid "Start reading commit messages at <replaceable>COMMIT-ISH</replaceable>."
 msgstr ""
 
 #. type: Content of: <refentry><refsect1><variablelist><varlistentry><term>

--- a/docs/po/gbp.pot
+++ b/docs/po/gbp.pot
@@ -731,7 +731,7 @@ msgid ""
 "~/.gbp.late.conf</filename> is at the very end of the list it can be used to "
 "override configuration entries shipped by the package. This can be useful if "
 "packages set e.g. <option>export-dir</option> or "
-"<option>tarball-dir</option> and you perfer different locations: "
+"<option>tarball-dir</option> and you prefer different locations: "
 "<placeholder type=\"programlisting\" id=\"0\"/>"
 msgstr ""
 
@@ -1748,7 +1748,7 @@ msgstr ""
 msgid ""
 "The basic idea is that patches are imported from your &debian-branch; to a "
 "patch-queue branch with one patch file in "
-"<filename>debian/patches/</filename> becoming one commit on the the "
+"<filename>debian/patches/</filename> becoming one commit on the "
 "patch-queue branch.  The created branch will be named after the branch you "
 "imported from with <filename>patch-queue/</filename> prepended. So if you do "
 "your &debian; packaging on <filename>debian/sid</filename> and do a"
@@ -1793,7 +1793,7 @@ msgstr ""
 #: chapters/patches.xml:49
 msgid ""
 "The main drawback of this workflow is the lack of history on the patch-queue "
-"branch since it is frequently droppend and recreated. But there is full "
+"branch since it is frequently dropped and recreated. But there is full "
 "history on the your &debian-branch;, of course."
 msgstr ""
 
@@ -2967,7 +2967,7 @@ msgstr ""
 #. type: Content of: <chapter><sect1><para>
 #: chapters/special.xml:247
 msgid ""
-"This will make sure packages are imported into a git respository after "
+"This will make sure packages are imported into a git repository after "
 "download."
 msgstr ""
 
@@ -5530,8 +5530,8 @@ msgid ""
 "<arg><option>--upstream-branch=</option><replaceable>branch_name</replaceable></arg> "
 "<arg><option>--upstream-tag=</option><replaceable>tag-format</replaceable></arg> "
 "<arg><option>--ignore-branch</option></arg> <group> <arg><option>-s</option> "
-"<replaceable>commitish</replaceable></arg> "
-"<arg><option>--since=</option><replaceable>commitish</replaceable></arg> "
+"<replaceable>commit-ish</replaceable></arg> "
+"<arg><option>--since=</option><replaceable>commit-ish</replaceable></arg> "
 "</group> <group> <group> <arg><option>-S</option></arg> "
 "<arg><option>--snapshot</option></arg> </group> <group> "
 "<arg><option>-R</option></arg> <arg><option>--release</option></arg> "
@@ -5590,7 +5590,7 @@ msgstr ""
 #: manpages/gbp-dch.xml:98
 msgid ""
 "If the topmost version of the <filename>debian/changelog</filename> is "
-"alread tagged. Use the commit the tag points to as start commit."
+"already tagged. Use the commit the tag points to as start commit."
 msgstr ""
 
 #. type: Content of: <refentry><refsect1><orderedlist><listitem><para>
@@ -5627,7 +5627,7 @@ msgstr ""
 #. type: Content of: <refentry><refsect1><para>
 #: manpages/gbp-dch.xml:123
 msgid ""
-"To restrict the selected changes even further you can use use the "
+"To restrict the selected changes even further you can use the "
 "<option>--git-log</option> option which is passed on verbatim to "
 "<command>git log</command>. E.g. by using "
 "<option>--git-log=</option><replaceable>\"--author=Foo Bar\"</replaceable>."
@@ -5688,13 +5688,13 @@ msgstr ""
 
 #. type: Content of: <refentry><refsect1><variablelist><varlistentry><term>
 #: manpages/gbp-dch.xml:203
-msgid "<option>--since=</option><replaceable>committish</replaceable>"
+msgid "<option>--since=</option><replaceable>commit-ish</replaceable>"
 msgstr ""
 
 #. type: Content of: <refentry><refsect1><variablelist><varlistentry><listitem><para>
 #: manpages/gbp-dch.xml:207
 msgid ""
-"Start reading commit messages at <replaceable>committish</replaceable>.  "
+"Start reading commit messages at <replaceable>commit-ish</replaceable>.  "
 "This option can't be set via &gbp.conf;."
 msgstr ""
 
@@ -7368,7 +7368,7 @@ msgstr ""
 #. type: Content of: <refentry><refsect1><para>
 #: manpages/gbp-import-ref.xml:219
 msgid ""
-"Merge commits from the the tag corresponding to version "
+"Merge commits from the tag corresponding to version "
 "<replaceable>1.0</replaceable>:"
 msgstr ""
 
@@ -8448,7 +8448,7 @@ msgstr ""
 msgid ""
 "If a <replaceable>remote</replaceable> is given on the command line the "
 "changes are pushed to the given remote repository. By default it will push "
-"to the current branchs remote and fall back to <emphasis>origin</emphasis>."
+"to the current branches remote and fall back to <emphasis>origin</emphasis>."
 msgstr ""
 
 #. type: Content of: <refentry><refsect1><variablelist><varlistentry><listitem><para>
@@ -8539,7 +8539,7 @@ msgid ""
 "<arg><option>--packaging-dir=</option><replaceable>DIRECTORY</replaceable></arg> "
 "<arg><option>--changelog-file=</option><replaceable>FILEPATH</replaceable></arg> "
 "<arg><option>--spec-file=</option><replaceable>FILEPATH</replaceable></arg> "
-"<arg><option>--since=</option><replaceable>COMMITISH</replaceable></arg> "
+"<arg><option>--since=</option><replaceable>COMMIT-ISH</replaceable></arg> "
 "<arg><option>--no-release</option></arg> "
 "<arg><option>--[no-]git-author</option></arg> "
 "<arg><option>--[no-]full</option></arg> "
@@ -8612,12 +8612,12 @@ msgstr ""
 
 #. type: Content of: <refentry><refsect1><variablelist><varlistentry><term>
 #: manpages/gbp-rpm-ch.xml:155
-msgid "<option>--since=</option><replaceable>COMMITTISH</replaceable>"
+msgid "<option>--since=</option><replaceable>COMMIT-ISH</replaceable>"
 msgstr ""
 
 #. type: Content of: <refentry><refsect1><variablelist><varlistentry><listitem><para>
 #: manpages/gbp-rpm-ch.xml:159
-msgid "Start reading commit messages at <replaceable>COMMITTISH</replaceable>."
+msgid "Start reading commit messages at <replaceable>COMMIT-ISH</replaceable>."
 msgstr ""
 
 #. type: Content of: <refentry><refsect1><variablelist><varlistentry><term>

--- a/examples/gbp-svn-tag
+++ b/examples/gbp-svn-tag
@@ -11,7 +11,7 @@ if [ "$DIST" = "UNRELEASED" ]; then
     echo "Distribution is unreleased"
     exit 1
 elif [ -z "$VERSION" ]; then
-    echo "Cant read package version"
+    echo "Can't read package version"
     exit 1
 fi
 

--- a/examples/jenkins-scratchbuilder
+++ b/examples/jenkins-scratchbuilder
@@ -21,7 +21,7 @@ rm -f *.deb *.changes *.build *.dsc
 # named scratchbuild
 cd scratchbuild/
 
-# Make sure we have an uptodate cowbuilder environment
+# Make sure we have an up-to-date cowbuilder environment
 # Note that git-pbuilder will pick up $DIST and $ARCH from the environment
 [ -d /var/cache/pbuilder/base.cow ] || git-pbuilder create
 git-pbuilder update

--- a/examples/zeitgeist-git.py
+++ b/examples/zeitgeist-git.py
@@ -28,7 +28,7 @@ in existing repositories or to
 
     /usr/share/git-core/templates
 
-so it get's used for new ones.
+so it gets used for new ones.
 """
 
 

--- a/gbp.conf
+++ b/gbp.conf
@@ -90,7 +90,7 @@
 #git-log = --no-merges
 # next snapshot number:
 #snapshot-number = snapshot + 1
-# include 7 digits of the commit id in the changelog enty:
+# include 7 digits of the commit id in the changelog entry:
 #id-length = 7
 # don't include information from meta tags:
 #meta = False
@@ -138,4 +138,3 @@
 remote-url-pattern = ssh://git.debian.org/git/pkg-libvirt/%(pkg)s
 # Template dir to passed to git-init
 template-dir = /srv/alioth.debian.org/chroot/home/groups/pkg-libvirt/git-template
-

--- a/gbp/config.py
+++ b/gbp/config.py
@@ -382,7 +382,7 @@ class GbpOptionParser(OptionParser):
         'component':
             'component name for additional tarballs',
         'bare':
-            "wether to create a bare repository on the remote side. "
+            "whether to create a bare repository on the remote side. "
             "'Default is '%(bare)s'.",
         'urgency':
             "Set urgency level, default is '%(urgency)s'",

--- a/gbp/dch.py
+++ b/gbp/dch.py
@@ -49,7 +49,7 @@ def filter_ignore_rx_matches(lines, options):
 
 def extract_bts_cmds(lines, opts):
     """Return a dictionary of the bug tracking system commands
-    contained in the the given lines.  i.e. {'closed' : [1], 'fixed':
+    contained in the given lines.  i.e. {'closed' : [1], 'fixed':
     [3, 4]}.  Right now, this will only notice a single directive
     clause on a line.  Also return all of the lines that do not
     contain bug tracking system commands."""

--- a/gbp/deb/changelog.py
+++ b/gbp/deb/changelog.py
@@ -244,7 +244,7 @@ class ChangeLog(object):
         @type email: C{str}
         @param newversion: start a new version
         @type newversion: C{bool}
-        @param version: the verion to use
+        @param version: the version to use
         @type version: C{str}
         @param release: finalize changelog for releaze
         @type release: C{bool}

--- a/gbp/deb/control.py
+++ b/gbp/deb/control.py
@@ -42,7 +42,7 @@ class Control(object):
         @param filename: name of the control file
         @type filename: C{str}
         @return: Control object
-        @rtype: C{gbp.deb.conrol.Control} object
+        @rtype: C{gbp.deb.control.Control} object
         """
         if contents:
             control = email.message_from_string(contents)

--- a/gbp/deb/git.py
+++ b/gbp/deb/git.py
@@ -213,7 +213,7 @@ class DebianGitRepository(PkgGitRepository):
 
         %(version%A%B)s provides %(version)s with string 'A' replaced by 'B'.
         This way, simple version mangling is possible via substitution.
-        Inside the substition string, '%' needs to be escaped. See the
+        Inside the substitution string, '%' needs to be escaped. See the
         examples below.
 
         >>> DebianGitRepository.version_to_tag("debian/%(version)s", "0:0~0")
@@ -347,7 +347,7 @@ class DebianGitRepository(PkgGitRepository):
         and (optional) component tarballs based on upstream_tree
 
         @param upstream_tree: the treeish in the git repo to create the commits against
-        @param soures: C{list} of tarball as I{UpstreamSource}. First one being the main
+        @param sources: C{list} of tarball as I{UpstreamSource}. First one being the main
                        tarball the other ones additional tarballs.
         """
         components = [t.component for t in sources[1:]]
@@ -411,7 +411,7 @@ class DebianGitRepository(PkgGitRepository):
         @type treeish: C{str}
         @param comp: compressor
         @type comp: L{Compressor}
-        @param with_submodules: wether to add submodules
+        @param with_submodules: whether to add submodules
         @type with_submodules: C{bool}
         @param component: component to add to tarball name
         @type component: C{str}

--- a/gbp/deb/uscan.py
+++ b/gbp/deb/uscan.py
@@ -76,7 +76,7 @@ class Uscan(object):
 
         @param out: uscan output
         @type out: string
-        @returns: C{True} if package is uptodate
+        @returns: C{True} if package is up-to-date
 
         >>> u = Uscan('http://example.com/')
         >>> u._parse_uptodate('<status>up to date</status>')
@@ -109,12 +109,12 @@ class Uscan(object):
         >>> u = Uscan('http://example.com/')
         >>> u._raise_error("<warnings>uscan warning: "
         ... "In watchfile debian/watch, reading webpage\n"
-        ... "http://a.b/ failed: 500 Cant connect "
+        ... "http://a.b/ failed: 500 Can't connect "
         ... "to example.com:80 (Bad hostname)</warnings>")
         Traceback (most recent call last):
         ...
         gbp.deb.uscan.UscanError: Uscan failed: uscan warning: In watchfile debian/watch, reading webpage
-        http://a.b/ failed: 500 Cant connect to example.com:80 (Bad hostname)
+        http://a.b/ failed: 500 Can't connect to example.com:80 (Bad hostname)
         >>> u._raise_error("<errors>uscan: Can't use --verbose if "
         ... "you're using --dehs!</errors>")
         Traceback (most recent call last):
@@ -148,8 +148,8 @@ class Uscan(object):
             cmd += ['--download-debversion', download_version]
         p = subprocess.Popen(cmd, cwd=self._dir, stdout=subprocess.PIPE)
         out = p.communicate()[0].decode()
-        # uscan exits with 1 in case of uptodate and when an error occurred.
-        # Don't fail in the uptodate case:
+        # uscan exits with 1 in case of up-to-date and when an error occurred.
+        # Don't fail in the up-to-date case:
         if self._parse_uptodate(out):
             return False
 

--- a/gbp/git/repository.py
+++ b/gbp/git/repository.py
@@ -637,7 +637,7 @@ class GitRepository(object):
         """
         Get upstream branch for the local branch
 
-        @param local_branch: name fo the local branch
+        @param local_branch: name of the local branch
         @type local_branch: C{str}
         @return: upstream (remote/branch) or  '' if no upstream found
         @rtype: C{str}
@@ -1468,7 +1468,7 @@ class GitRepository(object):
             raise GbpError("Failed to move '%s' to '%s': %s" % (old, new, stderr.decode().rstrip()))
 #}
 
-#{ Comitting
+#{ Committing
 
     def _commit(self, msg, args=[], author_info=None):
         extra_env = author_info.get_author_env() if author_info else None
@@ -1672,7 +1672,7 @@ class GitRepository(object):
 
     def grep_log(self, regex, since=None, merges=True):
         """
-        Get commmits matching I{regex}
+        Get commits matching I{regex}
 
         @param regex: regular expression
         @type regex: C{str}

--- a/gbp/git/vfs.py
+++ b/gbp/git/vfs.py
@@ -56,13 +56,13 @@ class GitVfs(object):
         def __exit__(self, exc_type, exc_val, exc_tb):
             self.close()
 
-    def __init__(self, repo, committish=None):
+    def __init__(self, repo, commitish=None):
         """
         @param repo: the git repository to act on
-        @param committish: the committish to act on
+        @param commitish: the commit-ish to act on
         """
         self._repo = repo
-        self._committish = committish or 'HEAD'
+        self._commitish = commitish or 'HEAD'
 
     def open(self, path, flags=None):
         flags = flags or 'r'
@@ -72,7 +72,7 @@ class GitVfs(object):
                 raise NotImplementedError("Flag '%s' unsupported so far" % flag)
         try:
             return GitVfs._File(self._repo.show(
-                "%s:%s" % (self._committish, path)),
+                "%s:%s" % (self._commitish, path)),
                 True if 'b' in flags else False)
         except GitRepositoryError as e:
             raise OSError(e)

--- a/gbp/pkg/pkgpolicy.py
+++ b/gbp/pkg/pkgpolicy.py
@@ -187,7 +187,7 @@ class PkgPolicy(object):
 
         %(version%A%B)s provides %(version)s with string 'A' replaced by 'B'.
         This way, simple version mangling is possible via substitution.
-        Inside the substition string, '%' needs to be escaped. See the
+        Inside the substitution string, '%' needs to be escaped. See the
         examples below.
 
         >>> PkgPolicy.version_subst("debian/%(version)s", "0:0~0")

--- a/gbp/rpm/policy.py
+++ b/gbp/rpm/policy.py
@@ -46,7 +46,7 @@ class RpmPkgPolicy(PkgPolicy):
     upstreamversion_re = re.compile("^[0-9][%s%s]*$" %
                                     (alnum, version_whitelist_chars))
     upstreamversion_msg = ("Upstream version numbers must start with a digit "
-                           "and can only containg alphanumerics or characters "
+                           "and can only containing alphanumerics or characters "
                            "in %s" % list(version_whitelist_chars))
 
     @classmethod

--- a/gbp/scripts/buildpackage.py
+++ b/gbp/scripts/buildpackage.py
@@ -199,7 +199,7 @@ def check_tag(options, repo, source):
 
 def get_pbuilder_dist(options, repo, native=False):
     """
-    Determin the dist to build for with pbuilder/cowbuilder
+    Determine the dist to build for with pbuilder/cowbuilder
     """
     dist = None
     if options.pbuilder_dist == 'DEP14':

--- a/gbp/scripts/export_orig.py
+++ b/gbp/scripts/export_orig.py
@@ -40,7 +40,7 @@ def prepare_upstream_tarballs(repo, source, options, tarball_dir, output_dir):
     - create tarball using git-archive
 
     Afterwards
-    - create pristine-tar commmits if pristine-tar-commit is in use
+    - create pristine-tar commits if pristine-tar-commit is in use
     - verify tarball checksums if pristine-tar is in use
     """
     if hasattr(options, 'no_create_orig') and options.no_create_orig:

--- a/gbp/scripts/import_ref.py
+++ b/gbp/scripts/import_ref.py
@@ -51,7 +51,7 @@ def get_commit_and_version_to_merge(repo, options):
             raise GbpError("%s is not a valid branch" % options.upstream_branch)
         commit = options.upstream_branch
     else:
-        # Use whatever is passed in as commitish
+        # Use whatever is passed in as commit-ish
         commit = "%s^{commit}" % options.upstream_tree
     return commit, version
 

--- a/gbp/scripts/pq.py
+++ b/gbp/scripts/pq.py
@@ -112,7 +112,7 @@ def generate_patches(repo, start, end, outdir, options):
 
 def compare_series(old, new):
     """
-    Compare new pathes to lists of patches already exported
+    Compare new paths to lists of patches already exported
 
     >>> compare_series(['# comment', 'a', 'b'], ['b', 'c'])
     (['c'], ['a'])
@@ -190,7 +190,7 @@ def find_upstream_commit(repo, branch, upstream_tag):
 
 
 def pq_on_upstream_tag(pq_from):
-    """Return True if the patch queue is based on the uptream tag,
+    """Return True if the patch queue is based on the upstream tag,
     False if its based on the debian packaging branch"""
     return True if pq_from.upper() == 'TAG' else False
 

--- a/gbp/scripts/push.py
+++ b/gbp/scripts/push.py
@@ -88,7 +88,7 @@ def do_push(repo, dests, to_push, dry_run):
 
 def get_push_src(repo, ref, tag):
     """
-    Determine wether we can push the ref
+    Determine whether we can push the ref
 
     If the ref is further ahead than the tag
     we only want to push up to this tag.

--- a/gbp/scripts/supercommand.py
+++ b/gbp/scripts/supercommand.py
@@ -119,7 +119,7 @@ def supercommand(argv=None):
         usage()
         return 0
     elif cmd == 'help' and len(args) > 1:
-        # Make the first argument after help the new commadn and
+        # Make the first argument after help the new command and
         # request it's help output
         cmd = args[1]
         args = [cmd, '--help']

--- a/gbp/scripts/tag.py
+++ b/gbp/scripts/tag.py
@@ -59,7 +59,7 @@ def perform_tagging(repo, source, options, hook_env=None):
     """
     Perform the tagging
 
-    Select brach to tag, create tag and run hooks
+    Select branch to tag, create tag and run hooks
     """
     branch = repo.branch
     if branch and is_pq_branch(branch):

--- a/tests/30_test_deb_changelog.py
+++ b/tests/30_test_deb_changelog.py
@@ -18,7 +18,7 @@ from gbp.command_wrappers import CommandExecFailed
 
 class TestQuoting(unittest.TestCase):
     def test_comma(self):
-        """Test we properly parse maitainers with comma #737623"""
+        """Test we properly parse maintainers with comma #737623"""
         changes = """git-buildpackage (0.9.2) unstable; urgency=low
 
   * List of changes

--- a/tests/component/deb/test_import_ref.py
+++ b/tests/component/deb/test_import_ref.py
@@ -73,7 +73,7 @@ class TestImportRef(ComponentTestBase):
         eq_(len(repo.get_commits()), 3)
 
     @RepoFixtures.quilt30(DEFAULT_DSC, opts=['--pristine-tar'])
-    def test_from_committish(self, repo):
+    def test_from_commitish(self, repo):
         """
         Test that importing a upstream git from another commit works
         """

--- a/tests/doctests/test_GitRepository.py
+++ b/tests/doctests/test_GitRepository.py
@@ -288,7 +288,7 @@ def test_get_upstream_branch():
 
 def test_tag():
     """
-    Create a tag named I{tag} and check its existance
+    Create a tag named I{tag} and check its existence
 
     Methods tested:
          - L{gbp.git.GitRepository.create_tag}

--- a/tests/testutils/__init__.py
+++ b/tests/testutils/__init__.py
@@ -27,7 +27,7 @@ __all__ = ['GbpLogTester', 'DebianGitTestRepo', 'OsReleaseFile',
 
 
 class OsReleaseFile(object):
-    """Repesents a simple file with key-value pairs"""
+    """Represents a simple file with key-value pairs"""
 
     def __init__(self, filename="/etc/os-release"):
         self._values = {}

--- a/tests/testutils/debiangittestrepo.py
+++ b/tests/testutils/debiangittestrepo.py
@@ -30,7 +30,7 @@ class DebianGitTestRepo(unittest.TestCase):
         Add a single file with name I{name} and content I{content}. If
         I{content} is C{none} the content of the file is undefined.
 
-        @param name: the file's path relativ to the git repo
+        @param name: the file's path relative to the git repo
         @type name: C{str}
         @param content: the file's content
         @type content: C{str}


### PR DESCRIPTION
Please provide feedback, give me time to finalize, and then merge the final version of this PR (so I get GitHub credits unlike happened in #25 and #26).

There are still a couple of things to tweak:

- Do you prefer "can't" or "can not" as a replacement for "cant"?
- Do you prefer "committish" or "commitish"?

```
± grep -rF commitish
debian/zsh/_gbp:		'--since=-[Start point for reading commits]:commitish:' \
debian/zsh/_gbp:		'--since=-[Start point for reading commits]:commitish:' \
gbp/git/repository.py:    def describe(self, commitish, pattern=None, longfmt=False, always=False,
gbp/git/repository.py:        @param commitish: the commit-ish to describe
gbp/git/repository.py:        @type commitish: C{str}
gbp/git/repository.py:        args.add(commitish)
gbp/git/repository.py:                                     (commitish, err.decode().strip()))
gbp/git/repository.py:    def get_commit_info(self, commitish):
gbp/git/repository.py:        @param commitish: the commit-ish to inspect
gbp/git/repository.py:        commit_sha1 = self.rev_parse("%s^0" % commitish)
gbp/git/repository.py:                                     % commitish)
gbp/git/repository.py:        return {'id': commitish,
gbp/scripts/import_ref.py:        # Use whatever is passed in as commitish
gbp/scripts/buildpackage_rpm.py:        info['commitish'] = repo.rev_parse('%s' % treeish)
gbp/scripts/buildpackage_rpm.py:        info['commitish'] = info['commit']
docs/manpages/gbp-dch.xml:	<arg><option>-s</option> <replaceable>commitish</replaceable></arg>
docs/manpages/gbp-dch.xml:        <arg><option>--since=</option><replaceable>commitish</replaceable></arg>
docs/po/gbp.pot:"<replaceable>commitish</replaceable></arg> "
docs/po/gbp.pot:"<arg><option>--since=</option><replaceable>commitish</replaceable></arg> "
docs/po/de.po:"option> <replaceable>commitish</replaceable></arg> <arg><option>--since=</"
docs/po/de.po:"option><replaceable>commitish</replaceable></arg> </group> <group> <group> "

± grep -rF committish
gbp/git/vfs.py:    def __init__(self, repo, committish=None):
gbp/git/vfs.py:        @param committish: the committish to act on
gbp/git/vfs.py:        self._committish = committish or 'HEAD'
gbp/git/vfs.py:                "%s:%s" % (self._committish, path)),
tests/component/deb/test_import_ref.py:    def test_from_committish(self, repo):
docs/manpages/gbp-dch.xml:        <term><option>--since=</option><replaceable>committish</replaceable>
docs/manpages/gbp-dch.xml:            <replaceable>committish</replaceable>.
docs/po/gbp.pot:msgid "<option>--since=</option><replaceable>committish</replaceable>"
docs/po/gbp.pot:"Start reading commit messages at <replaceable>committish</replaceable>.  "
docs/po/de.po:msgid "<option>--since=</option><replaceable>committish</replaceable>"
docs/po/de.po:"Start reading commit messages at <replaceable>committish</replaceable>.  "
```