### PR TITLE
Salsa-CI: Disable SALSA_CI_DISABLE_VERSION_BUMP

### DIFF
--- a/debian/salsa-ci.yml
+++ b/debian/salsa-ci.yml
@@ -6,4 +6,4 @@ include:
 # Reprotest triggers a test failure not related to reproducibility
 variables:
   SALSA_CI_DISABLE_REPROTEST: 1
-
+  SALSA_CI_DISABLE_VERSION_BUMP: 1


### PR DESCRIPTION
Salsa-CI jobs 'build' and 'build i386' were failing on the error:

    /usr/lib/python3/dist-packages/setuptools/dist.py:509: SetuptoolsDeprecationWarning: Invalid version: '0.9.33+salsaci+20240105+6'.
    !!
        ********************************************************************************
        The version specified is not a valid version according to PEP 440.

Disabling the version automatic version bump in Salsa-CI satisfies Python setuptools and build passes.