### PR TITLE
dscfile.py: decide native/non-native based on diff presence, not vers…

### DIFF
--- a/gbp/deb/dscfile.py
+++ b/gbp/deb/dscfile.py
@@ -39,7 +39,7 @@ class DscFile(object):
                          r'\.diff.(gz|bz2))$')
     deb_tgz_re = re.compile(r'^\s\w+\s\d+\s+(?P<deb_tgz>[^_]+_[^_]+'
                             r'\.debian.tar.%s)$' % compressions)
-    format_re = re.compile(r'Format:\s+(?P<format>[0-9.]+)\s*')
+    format_re = re.compile(r'Format:\s+(?P<format>[0-9.]+)\s*(?:\((?P<subtype>native|quilt|git)\))?')
     sig_re = re.compile(r'^\s\w+\s\d+\s+(?P<sig>[^_]+_[^_]+'
                         r'\.orig(-[a-z0-9-]+)?\.tar\.%s.asc)$' % compressions)
 
@@ -60,12 +60,27 @@ class DscFile(object):
         except UnicodeDecodeError:
             raise GbpError(f"{self.dscfile} is not UTF-8 encoded")
 
-        # Source format 1.0 can have non-native packages without a Debian revision:
-        # e.g. http://snapshot.debian.org/archive/debian/20090801T192339Z/pool/main/l/latencytop/latencytop_0.5.dsc
-        if self.pkgformat == "1.0" and self.diff:
-            self.native = False
-        elif not self.native and not self.debian_version:
-            raise GbpError("Cannot parse Debian version number from '%s'" % self.dscfile)
+        if self.pkgformat == "1.0":
+            self.native = self.diff == ""
+        else:
+            self.native = self.subtype == 'native'
+        if self.native:
+            # Source format 1.0 native versions may contain hyphens.  Examples:
+            # http://snapshot.debian.org/package/python3-defaults/3.10.6-1/
+            # http://archive.ubuntu.com/ubuntu/pool/main/p/pam/pam_1.1.8-3.6ubuntu2.18.04.6.dsc
+            self.upstream_version = self.full_version
+        else:
+            self.upstream_version, separator, self.debian_version = self.full_version.rpartition('-')
+            if separator:
+                if not self.debian_version:
+                    raise GbpError("Cannot parse Debian version number from '%s'" % self.dscfile)
+                if not self.upstream_version:
+                    raise GbpError("Cannot parse upstream version number from '%s'" % self.dscfile)
+            else:
+                # Source format 1.0 non-native versions without hyphen:
+                # http://snapshot.debian.org/package/latencytop/0.5/
+                self.upstream_version = self.full_version
+                self.debian_version = ''
 
         if not self.pkg:
             raise GbpError("Cannot parse package name from '%s'" % self.dscfile)
@@ -81,18 +96,9 @@ class DscFile(object):
 
         for line in f:
             m = self.version_re.match(line)
-            if m and not self.upstream_version:
-                if '-' in m.group('version'):
-                    self.debian_version = m.group('version').split("-")[-1]
-                    self.upstream_version = "-".join(m.group('version').split("-")[0:-1])
-                    self.native = False
-                else:
-                    self.native = True  # Debian native package
-                    self.upstream_version = m.group('version')
-                if m.group('epoch'):
-                    self.epoch = m.group('epoch')
-                else:
-                    self.epoch = ""
+            if m:
+                self.full_version = m.group('version')
+                self.epoch = m.group('epoch') or ''
                 continue
             m = self.pkg_re.match(line)
             if m:
@@ -122,6 +128,7 @@ class DscFile(object):
             m = self.format_re.match(line)
             if m:
                 self.pkgformat = m.group('format')
+                self.subtype = m.group('subtype') or ''
                 continue
 
         self.additional_tarballs = dict(add_tars)

--- a/tests/12_test_deb.py
+++ b/tests/12_test_deb.py
@@ -125,13 +125,76 @@ Files:
         os.unlink(self.dscfile.name)
 
     def test_dscfile_parse(self):
-        """Test parsing a a 1.0 non-native dsc file without debian revision"""
+        """Test parsing a 1.0 non-native dsc file without debian revision"""
         dsc = DscFile.parse(self.dscfile.name)
         self.assertEqual(dsc.version, '0.5')
         self.assertEqual(dsc.native, False)
         self.assertEqual(os.path.basename(dsc.tgz), 'latencytop_0.5.orig.tar.gz')
         self.assertEqual(os.path.basename(dsc.deb_tgz), '')
         self.assertEqual(os.path.basename(dsc.diff), 'latencytop_0.5.diff.gz')
+        self.assertEqual(dsc.additional_tarballs, {}),
+        self.assertEqual(dsc.sigs, [])
+
+
+class Test10DscNativeFileWithDebianRevision(unittest.TestCase):
+    """Test L{gbp.deb.DscFile} with version string containing a Debian revision part"""
+
+    content = """Format: 1.0
+Source: python3-defaults
+Binary: python3, python3-venv, python3-minimal, python3-nopie, python3-examples, python3-dev, libpython
+3-dev, libpython3-stdlib, idle, python3-doc, python3-dbg, libpython3-dbg, python3-all, python3-all-dev,
+ python3-all-dbg, python3-all-venv, libpython3-all-dev, libpython3-all-dbg, 2to3, python3-full
+Architecture: any all
+Version: 3.12.4-1
+Maintainer: Matthias Klose <doko@debian.org>
+Uploaders: Piotr Ożarowski <piotr@debian.org>, Stefano Rivera <stefanor@debian.org>
+Homepage: https://www.python.org/
+Standards-Version: 4.6.2
+Vcs-Browser: https://salsa.debian.org/cpython-team/python3-defaults
+Vcs-Git: https://salsa.debian.org/cpython-team/python3-defaults.git
+Build-Depends: debhelper (>= 11), dpkg-dev (>= 1.17.11), python3.12:any (>= 3.12.4-1~), python3.12-minimal:any, python3-docutils <!nodoc>, python3-sphinx <!nodoc>, html2text (>= 2) <!nodoc>
+Package-List:
+ 2to3 deb python optional arch=all
+ idle deb python optional arch=all
+ libpython3-all-dbg deb debug optional arch=any
+ libpython3-all-dev deb libdevel optional arch=any
+ libpython3-dbg deb debug optional arch=any
+ libpython3-dev deb libdevel optional arch=any
+ libpython3-stdlib deb python optional arch=any
+ python3 deb python optional arch=any
+ python3-all deb python optional arch=any
+ python3-all-dbg deb debug optional arch=any
+ python3-all-dev deb python optional arch=any
+ python3-all-venv deb python optional arch=any
+ python3-dbg deb debug optional arch=any
+ python3-dev deb python optional arch=any
+ python3-doc deb doc optional arch=all
+ python3-examples deb python optional arch=all
+ python3-full deb python optional arch=any
+ python3-minimal deb python optional arch=any
+ python3-nopie deb python optional arch=any
+ python3-venv deb python optional arch=any
+Checksums-Sha1:
+ 2eed084fb55c6f903413b0c9cc876e2e31197133 146851 python3-defaults_3.12.4-1.tar.gz
+Checksums-Sha256:
+ 5ed419073282df22cddeb50a44b36f5607104d52999b93525dcd3970ea9a478f 146851 python3-defaults_3.12.4-1.tar.gz
+"""
+
+    def setUp(self):
+        with tempfile.NamedTemporaryFile(delete=False) as self.dscfile:
+            self.dscfile.write(self.content.encode())
+
+    def tearDown(self):
+        os.unlink(self.dscfile.name)
+
+    def test_dscfile_parse(self):
+        """Test parsing a 1.0 native dsc file with debian revision"""
+        dsc = DscFile.parse(self.dscfile.name)
+        self.assertEqual(dsc.version, '3.12.4-1')
+        self.assertEqual(dsc.native, True)
+        self.assertEqual(os.path.basename(dsc.tgz), 'python3-defaults_3.12.4-1.tar.gz')
+        self.assertEqual(os.path.basename(dsc.deb_tgz), '')
+        self.assertEqual(os.path.basename(dsc.diff), '')
         self.assertEqual(dsc.additional_tarballs, {}),
         self.assertEqual(dsc.sigs, [])
 


### PR DESCRIPTION
…ion format

Source format 1.0 native packages with a hyphen in their version number were mistaken by the original code for non-native.  For example:

$ git init --initial-branch=master
Initialized empty Git repository in /tmp/p3d/.git/ $ gbp import-dsc --allow-unauthenticated --create-missing-branches http://snapshot.debian.org/archive/debian/20240720T144054Z/pool/main/p/python3-defaults/python3-defaults_3.12.4-1.dsc gbp:info: Downloading 'http://snapshot.debian.org/archive/debian/20240720T144054Z/pool/main/p/python3-defaults/python3-defaults_3.12.4-1.dsc' using 'dget'... gbp:warning: Didn't find a diff to apply.
gbp:info: Version '3.12.4-1' imported under '/tmp/p3d' $ gbp import-dsc --allow-unauthenticated http://snapshot.debian.org/archive/debian/20240808T091320Z/pool/main/p/python3-defaults/python3-defaults_3.12.5-1.dsc gbp:info: Downloading 'http://snapshot.debian.org/archive/debian/20240808T091320Z/pool/main/p/python3-defaults/python3-defaults_3.12.5-1.dsc' using 'dget'... gbp:warning: Didn't find a diff to apply.
gbp:info: Version '3.12.5-1' imported under '/tmp/p3d' $ git log --oneline
740baad (HEAD -> master, tag: upstream/3.12.4) Import Upstream version 3.12.4 $ git log --oneline upstream
f662363 (tag: upstream/3.12.5, upstream) Import Upstream version 3.12.5 740baad (HEAD -> master, tag: upstream/3.12.4) Import Upstream version 3.12.4

The symptoms are the "Didn't find a diff to apply" warnings, using an "upstream" branch and leaving the "master" branch behind. After this change the same commands result in:

$ git init --initial-branch=master
Initialized empty Git repository in /tmp/p3d/.git/ $ gbp import-dsc --allow-unauthenticated --create-missing-branches http://snapshot.debian.org/archive/debian/20240720T144054Z/pool/main/p/python3-defaults/python3-defaults_3.12.4-1.dsc gbp:info: Downloading 'http://snapshot.debian.org/archive/debian/20240720T144054Z/pool/main/p/python3-defaults/python3-defaults_3.12.4-1.dsc' using 'dget'... gbp:info: Tag debian/3.12.4-1 not found, importing Debian tarball gbp:info: Version '3.12.4-1' imported under '/tmp/p3d' $ gbp import-dsc --allow-unauthenticated http://snapshot.debian.org/archive/debian/20240808T091320Z/pool/main/p/python3-defaults/python3-defaults_3.12.5-1.dsc gbp:info: Downloading 'http://snapshot.debian.org/archive/debian/20240808T091320Z/pool/main/p/python3-defaults/python3-defaults_3.12.5-1.dsc' using 'dget'... gbp:info: Tag debian/3.12.5-1 not found, importing Debian tarball gbp:info: Version '3.12.5-1' imported under '/tmp/p3d' $ git log --oneline
4dd04b9 (HEAD -> master, tag: debian/3.12.5-1) Import Debian version 3.12.5-1 107717c (tag: debian/3.12.4-1) Import Debian version 3.12.4-1

No warnings and a single "master" branch with two commits, which means the package was handled as native.

Source format 3.0 has a separate subtype for native packages, so that case is straightforward as well.