### PR TITLE
p/git-buildpackage.spec: Fix version to align to latest tag

### DIFF
--- a/packaging/git-buildpackage.spec
+++ b/packaging/git-buildpackage.spec
@@ -9,7 +9,7 @@
 
 Name:       git-buildpackage
 Summary:    Build packages from git
-Version:    0.9.38
+Version:    0.9.39
 Release:    0
 Group:      Development/Tools/Building
 License:    GPLv2


### PR DESCRIPTION
Currently base tag is "debian/0.9.39".

BTW would it make sense to have upstream tags without debian prefixes ?