### PR TITLE
buildpackage: Include uncommitted changes with --git-ignore-new and export-dir

### DIFF
--- a/docs/chapters/building.xml
+++ b/docs/chapters/building.xml
@@ -58,6 +58,11 @@
     state of the current index, which can be used to include staged but uncommitted
     changes in the build. Whereas the special argument
     <replaceable>WC</replaceable> exports the current working copy as is.</para>
+    <para>By default uncommitted changes are not exported and
+    &gbp-buildpackage; aborts when it finds them. Passing
+    <option>--git-ignore-new</option> includes the uncommitted changes (both
+    modified and untracked files) in the exported tree, mirroring the behaviour
+    of building without <option>--git-export-dir</option>.</para>
     <para>If you want to default to build in a separate build area, you can
     specify the directory to use in the <filename>gbp.conf</filename> file.
 <programlisting>

--- a/docs/manpages/gbp-buildpackage.xml
+++ b/docs/manpages/gbp-buildpackage.xml
@@ -758,7 +758,11 @@
             <para>
               Don't abort if there are uncommitted changes in the source tree or
               the current branch doesn't match the
-              <replaceable>DEBIAN-BRANCH</replaceable>.
+              <replaceable>DEBIAN-BRANCH</replaceable>. The uncommitted changes
+              are included in the build. This holds whether or not
+              <option>--git-export-dir</option> is used, as long as
+              <option>--git-export</option> is left at its default
+              (<replaceable>HEAD</replaceable>).
             </para>
           </listitem>
 	</varlistentry>

--- a/gbp/scripts/buildpackage.py
+++ b/gbp/scripts/buildpackage.py
@@ -62,6 +62,13 @@ def maybe_write_tree(repo: DebianGitRepository, options: optparse.Values) -> str
             tree = repo.write_tree()
         elif options.export == wc_name:
             tree = write_wc(repo)
+        elif options.ignore_new and options.export == 'HEAD':
+            # --git-ignore-new asks to build with the uncommitted changes
+            # in the source tree. Without an export-dir we build in the
+            # working copy and the changes are included, so export the
+            # working copy here too to keep the behaviour consistent
+            # (#1091531).
+            tree = write_wc(repo)
         else:
             tree = options.export
         if not repo.has_treeish(tree):

--- a/tests/component/deb/test_buildpackage.py
+++ b/tests/component/deb/test_buildpackage.py
@@ -222,6 +222,37 @@ class TestBuildpackage(ComponentTestBase):
         self._test_buildpackage(repo, ["--git-export=WC", "--git-export-dir=../foo/bar"])
         assert os.path.exists("../foo/bar")
 
+    @RepoFixtures.quilt30()
+    def test_export_dir_ignore_new(self, repo):
+        """
+        Test that --git-ignore-new includes uncommitted changes in the export
+        when an export dir is used (#1091531).
+
+        Without an export dir the package is built in-place in the working copy
+        so uncommitted changes are always part of the build. With an export dir
+        the tree to export defaults to HEAD, which used to silently drop those
+        changes. Before the fix both assertions below failed because HEAD was
+        exported instead of the working copy.
+        """
+        # Uncommitted modification to a tracked file ...
+        rules = os.path.join(repo.path, 'debian', 'rules')
+        with open(rules, 'a') as f:
+            f.write('\n# uncommitted-marker\n')
+        # ... and an untracked new file
+        with open(os.path.join(repo.path, 'untracked.txt'), 'w') as f:
+            f.write('untracked')
+
+        self._test_buildpackage(repo, ['--git-ignore-new',
+                                       '--git-no-purge',
+                                       '--git-export-dir=../bdir'])
+
+        exported = '../bdir/hello-debhelper-2.8'
+        with open(os.path.join(exported, 'debian', 'rules')) as f:
+            assert '# uncommitted-marker' in f.read(), \
+                "Uncommitted change to tracked file was not exported"
+        assert os.path.exists(os.path.join(exported, 'untracked.txt')), \
+            "Untracked file was not exported"
+
     @RepoFixtures.native()
     def test_argument_quoting(self, repo):
         """Test that we quote arguments to builder (#850869)"""


### PR DESCRIPTION
With --git-export-dir set, the tree to export defaulted to HEAD, so --git-ignore-new silently dropped uncommitted changes. This was inconsistent with building in-place (no export-dir), which builds the working copy and therefore includes them. The option is documented as "Build with uncommitted changes in the source tree", so the changes should end up in the build regardless of export-dir.

Export the working copy when --git-ignore-new is given and --git-export is left at its default (HEAD).

Closes: #1091531

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1091531